### PR TITLE
Portali za upravljanje #52

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,15 +35,15 @@ jobs:
           - 5432:5432
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: maven
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     # - name: Update dependency graph

--- a/bank-service/pom.xml
+++ b/bank-service/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/bank-service/pom.xml
+++ b/bank-service/pom.xml
@@ -37,7 +37,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+            <version>3.1.3</version>
+        </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>

--- a/bank-service/src/main/java/rs/raf/bank_service/BankServiceApplication.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/BankServiceApplication.java
@@ -2,8 +2,10 @@ package rs.raf.bank_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients(basePackages = "rs.raf.bank_service.client")
 public class BankServiceApplication {
 
     public static void main(String[] args) {

--- a/bank-service/src/main/java/rs/raf/bank_service/bootstrap/BootstrapData.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/bootstrap/BootstrapData.java
@@ -1,31 +1,109 @@
 package rs.raf.bank_service.bootstrap;
 
-import lombok.AllArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import rs.raf.bank_service.domain.entity.Card;
+import rs.raf.bank_service.domain.entity.CompanyAccount;
 import rs.raf.bank_service.domain.entity.Currency;
+import rs.raf.bank_service.domain.entity.PersonalAccount;
+import rs.raf.bank_service.domain.enums.AccountOwnerType;
+import rs.raf.bank_service.domain.enums.AccountStatus;
+import rs.raf.bank_service.domain.enums.AccountType;
+import rs.raf.bank_service.domain.enums.CardStatus;
+import rs.raf.bank_service.repository.AccountRepository;
+import rs.raf.bank_service.repository.CardRepository;
 import rs.raf.bank_service.repository.CurrencyRepository;
 
-@AllArgsConstructor
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
 @Component
 public class BootstrapData implements CommandLineRunner {
+
+    private final AccountRepository accountRepository;
+    private final CardRepository cardRepository;
     private final CurrencyRepository currencyRepository;
+
+    public BootstrapData(AccountRepository accountRepository, CardRepository cardRepository, CurrencyRepository currencyRepository) {
+        this.accountRepository = accountRepository;
+        this.cardRepository = cardRepository;
+        this.currencyRepository = currencyRepository;
+    }
 
     @Override
     public void run(String... args) throws Exception {
-        if (currencyRepository.count() == 0) {
-            Currency currencyEuro = Currency.builder()
-                    .code("EUR")
-                    .name("Euro")
-                    .symbol("€")
-                    .countries("Montenegro,Greece,Germany")
-                    .description("Euro neuro")
-                    .active(true)
-                    .build();
+        // Kreiramo valutu
+        Currency currency = new Currency();
+        currency.setCode("EUR");
+        currency.setName("Euro");
+        currency.setSymbol("€");
+        currency.setCountries("EU");
+        currency.setDescription("Euro currency");
+        currency.setActive(true);
+        currencyRepository.save(currency);
 
+        // Postavka računa (podaci za bank service koriste ID-jeve kreiranih klijenata u client service):
+        // Pretpostavljamo da je prvi klijent (Marko Markovic) sa ID 1, a drugi (Jovan Jovanovic) sa ID 2.
 
-            currencyRepository.save(currencyEuro);
-        }
+        // Tekući račun (lični) – za klijenta sa ID 2
+        PersonalAccount currentAccount = new PersonalAccount();
+        currentAccount.setAccountNumber("111111111111111111");
+        currentAccount.setClientId(2L);             // Klijent: Marko Markovic (lični)
+        currentAccount.setCreatedByEmployeeId(100L);
+        currentAccount.setCreationDate(LocalDate.now().minusMonths(1));
+        currentAccount.setExpirationDate(LocalDate.now().plusYears(5));
+        currentAccount.setCurrency(currency);
+        currentAccount.setStatus(AccountStatus.ACTIVE);
+        currentAccount.setBalance(BigDecimal.valueOf(1000));
+        currentAccount.setAvailableBalance(BigDecimal.valueOf(900));
+        currentAccount.setDailyLimit(BigDecimal.valueOf(500));
+        currentAccount.setMonthlyLimit(BigDecimal.valueOf(5000));
+        currentAccount.setDailySpending(BigDecimal.ZERO);
+        currentAccount.setMonthlySpending(BigDecimal.ZERO);
+        currentAccount.setType(AccountType.CURRENT);
+        currentAccount.setAccountOwnerType(AccountOwnerType.PERSONAL);
+        accountRepository.save(currentAccount);
 
+        // Devizni račun (poslovni) – za klijenta sa ID 1
+        CompanyAccount foreignAccount = new CompanyAccount();
+        foreignAccount.setAccountNumber("222222222222222222");
+        foreignAccount.setClientId(1L);              // Klijent: Jovan Jovanovic (poslovni)
+        foreignAccount.setCompanyId(200L);           // Poslovni račun, ima companyId
+        foreignAccount.setCreatedByEmployeeId(101L);
+        foreignAccount.setCreationDate(LocalDate.now().minusMonths(2));
+        foreignAccount.setExpirationDate(LocalDate.now().plusYears(3));
+        foreignAccount.setCurrency(currency);
+        foreignAccount.setStatus(AccountStatus.ACTIVE);
+        foreignAccount.setBalance(BigDecimal.valueOf(2000));
+        foreignAccount.setAvailableBalance(BigDecimal.valueOf(1800));
+        foreignAccount.setDailyLimit(BigDecimal.valueOf(1000));
+        foreignAccount.setMonthlyLimit(BigDecimal.valueOf(10000));
+        foreignAccount.setDailySpending(BigDecimal.ZERO);
+        foreignAccount.setMonthlySpending(BigDecimal.ZERO);
+        foreignAccount.setType(AccountType.FOREIGN);
+        foreignAccount.setAccountOwnerType(AccountOwnerType.COMPANY);
+        accountRepository.save(foreignAccount);
+
+        // Kreiramo karticu za tekući račun (Marko Markovic)
+        Card card1 = new Card();
+        card1.setCardNumber("1234123412341234");
+        card1.setCvv("123");
+        card1.setCreationDate(LocalDate.now().minusDays(10));
+        card1.setExpirationDate(LocalDate.now().plusYears(3));
+        card1.setAccount(currentAccount);
+        card1.setStatus(CardStatus.ACTIVE);
+        card1.setCardLimit(BigDecimal.valueOf(500));
+        cardRepository.save(card1);
+
+        // Kreiramo karticu za devizni račun (Jovan Jovanovic)
+        Card card2 = new Card();
+        card2.setCardNumber("4321432143214321");
+        card2.setCvv("321");
+        card2.setCreationDate(LocalDate.now().minusDays(5));
+        card2.setExpirationDate(LocalDate.now().plusYears(2));
+        card2.setAccount(foreignAccount);
+        card2.setStatus(CardStatus.ACTIVE);
+        card2.setCardLimit(BigDecimal.valueOf(1000));
+        cardRepository.save(card2);
     }
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/client/FeignClientInterceptor.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/client/FeignClientInterceptor.java
@@ -1,0 +1,21 @@
+package rs.raf.bank_service.client;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/// Ova komponenta sluzi da u sve Feign pozive ubaci token koji nam treba da bi mogli da radimo autorizaciju za komunikaciju izmedju servisa trenutno radi testiranja
+@Component
+public class FeignClientInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate template) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getCredentials() != null) {
+            String token = authentication.getCredentials().toString();
+            template.header("Authorization", "Bearer " + token);
+        }
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/client/UserClient.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/client/UserClient.java
@@ -1,0 +1,14 @@
+package rs.raf.bank_service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import rs.raf.bank_service.domain.dto.ClientDto;
+
+/// Klasa koja sluzi za slanje HTTP poziva na userService
+@FeignClient(name = "user-service", url = "${user.service.url:http://localhost:8080}")
+public interface UserClient {
+
+    @GetMapping("/api/admin/clients/{id}")
+    ClientDto getClientById(@PathVariable("id") Long id);
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/configuration/RabbitMQConfig.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/configuration/RabbitMQConfig.java
@@ -1,6 +1,5 @@
 package rs.raf.bank_service.configuration;
 
-import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;

--- a/bank-service/src/main/java/rs/raf/bank_service/configuration/SpringSecurityConfig.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/configuration/SpringSecurityConfig.java
@@ -1,5 +1,6 @@
 package rs.raf.bank_service.configuration;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -13,8 +14,11 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import rs.raf.bank_service.security.JwtAuthenticationFilter;
+import rs.raf.bank_service.utils.DummyAuthenticationFilter;
 
 import java.util.List;
+
+import static javax.management.Query.and;
 
 @CrossOrigin("*")
 @EnableWebSecurity
@@ -23,6 +27,11 @@ import java.util.List;
 public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+
+    //SAMO ZA POTREBE TESTIRANJA KOMUNIKACIJE IZMEDJU USER I BANK SERVICE DOK SE NE USPOSTAVI PRAVILAN TOK JER OVAKO NEMAMO TOKEN
+    @Autowired
+    private DummyAuthenticationFilter dummyAuthenticationFilter;
 
     public SpringSecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
@@ -40,12 +49,17 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/swagger-ui.html").permitAll()
                 .antMatchers("/swagger-ui/**").permitAll()
                 .antMatchers("/api-docs/**").permitAll()
+                .antMatchers("/api/account/**").hasAnyAuthority("admin")
                 .anyRequest().authenticated()
                 .and().sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and().headers()
                 .frameOptions().disable()
-                .and().addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+              //  .and().addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                //SAMO ZA POTREBE TESTIRANJA KOMUNIKACIJE IZMEDJU USER I BANK SERVICE DOK SE NE USPOSTAVI PRAVILAN TOK JER OVAKO NEMAMO TOKEN
+                .and().addFilterBefore(dummyAuthenticationFilter,
+                        org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);
+        //
 
     }
     @Bean

--- a/bank-service/src/main/java/rs/raf/bank_service/configuration/SpringSecurityConfig.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/configuration/SpringSecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -17,8 +16,6 @@ import rs.raf.bank_service.security.JwtAuthenticationFilter;
 import rs.raf.bank_service.utils.DummyAuthenticationFilter;
 
 import java.util.List;
-
-import static javax.management.Query.and;
 
 @CrossOrigin("*")
 @EnableWebSecurity
@@ -55,13 +52,14 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and().headers()
                 .frameOptions().disable()
-              //  .and().addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                //  .and().addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
                 //SAMO ZA POTREBE TESTIRANJA KOMUNIKACIJE IZMEDJU USER I BANK SERVICE DOK SE NE USPOSTAVI PRAVILAN TOK JER OVAKO NEMAMO TOKEN
                 .and().addFilterBefore(dummyAuthenticationFilter,
                         org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);
         //
 
     }
+
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();

--- a/bank-service/src/main/java/rs/raf/bank_service/controller/AccountController.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/controller/AccountController.java
@@ -52,14 +52,14 @@ public class AccountController {
             @ApiResponse(responseCode = "201", description = "Account created successfully"),
             @ApiResponse(responseCode = "400", description = "Invalid input data")
     })
-    public ResponseEntity<String> createBankAccount(@RequestHeader("Authorization") String authorizationHeader, @RequestBody NewBankAccountDto newBankAccountDto){
+    public ResponseEntity<String> createBankAccount(@RequestHeader("Authorization") String authorizationHeader, @RequestBody NewBankAccountDto newBankAccountDto) {
         try {
-            accountService.createNewBankAccount(newBankAccountDto,authorizationHeader);
+            accountService.createNewBankAccount(newBankAccountDto, authorizationHeader);
 //            if(newBankAccountDto.isCreateCard()){
 //                accountService.createCard...
 //            }
             return ResponseEntity.status(HttpStatus.CREATED).build();
-        }catch (ClientNotFoundException | CurrencyNotFoundException e) {
+        } catch (ClientNotFoundException | CurrencyNotFoundException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         }
     }

--- a/bank-service/src/main/java/rs/raf/bank_service/controller/AccountController.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/controller/AccountController.java
@@ -5,10 +5,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import rs.raf.bank_service.domain.dto.AccountDto;
 import rs.raf.bank_service.domain.dto.NewBankAccountDto;
 import rs.raf.bank_service.exceptions.ClientNotFoundException;
 import rs.raf.bank_service.exceptions.CurrencyNotFoundException;
@@ -21,6 +27,23 @@ public class AccountController {
 
     @Autowired
     private AccountService accountService;
+
+    /// GET endpoint sa opcionalnim filterima i paginacijom/sortiranjem po prezimenu vlasnika
+    @PreAuthorize("hasAuthority('admin')")
+    @Operation(summary = "Get all accounts with filtering and pagination")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "Accounts retrieved successfully")})
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Page<AccountDto>> getAccounts(
+            @RequestParam(required = false) String accountNumber,
+            @RequestParam(required = false) String firstName,
+            @RequestParam(required = false) String lastName,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("owner.lastName").ascending());
+        Page<AccountDto> accounts = accountService.getAccounts(accountNumber, firstName, lastName, pageable);
+        return ResponseEntity.ok(accounts);
+    }
 
     @PreAuthorize("hasAuthority('employee')")
     @PostMapping

--- a/bank-service/src/main/java/rs/raf/bank_service/controller/CardController.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/controller/CardController.java
@@ -1,0 +1,117 @@
+package rs.raf.bank_service.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import rs.raf.bank_service.domain.dto.CardDto;
+import rs.raf.bank_service.domain.enums.CardStatus;
+import rs.raf.bank_service.service.CardService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/account/{accountNumber}/cards")
+public class CardController {
+
+    private final CardService cardService;
+
+    public CardController(CardService cardService) {
+        this.cardService = cardService;
+    }
+
+    @PreAuthorize("hasAuthority('admin')")
+    @GetMapping
+    @Operation(
+            summary = "Get Cards by Account",
+            description = "Retrieves all cards associated with the specified account number."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Cards retrieved successfully"),
+            @ApiResponse(responseCode = "403", description = "Access denied")
+    })
+    public ResponseEntity<List<CardDto>> getCardsByAccount(
+            @Parameter(
+                    description = "Account number for which cards are retrieved",
+                    in = ParameterIn.PATH,
+                    required = true,
+                    example = "222222222222222222"
+            )
+            @PathVariable String accountNumber) {
+        List<CardDto> cards = cardService.getCardsByAccount(accountNumber);
+        return ResponseEntity.ok(cards);
+    }
+
+    @PreAuthorize("hasAuthority('admin')")
+    @PostMapping("/{cardNumber}/block")
+    @Operation(
+            summary = "Block Card",
+            description = "Blocks the card identified by the provided card number."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Card blocked successfully"),
+            @ApiResponse(responseCode = "404", description = "Card not found"),
+            @ApiResponse(responseCode = "403", description = "Access denied")
+    })
+    public ResponseEntity<Void> blockCard(
+            @Parameter(
+                    description = "Card number to block",
+                    in = ParameterIn.PATH,
+                    required = true,
+                    example = "1234123412341234"
+            )
+            @PathVariable String cardNumber) {
+        cardService.changeCardStatus(cardNumber, CardStatus.BLOCKED);
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasAuthority('admin')")
+    @PostMapping("/{cardNumber}/unblock")
+    @Operation(
+            summary = "Unblock Card",
+            description = "Unblocks the card identified by the provided card number."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Card unblocked successfully"),
+            @ApiResponse(responseCode = "404", description = "Card not found"),
+            @ApiResponse(responseCode = "403", description = "Access denied")
+    })
+    public ResponseEntity<Void> unblockCard(
+            @Parameter(
+                    description = "Card number to unblock",
+                    in = ParameterIn.PATH,
+                    required = true,
+                    example = "1234123412341234"
+            )
+            @PathVariable String cardNumber) {
+        cardService.changeCardStatus(cardNumber, CardStatus.ACTIVE);
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasAuthority('admin')")
+    @PostMapping("/{cardNumber}/deactivate")
+    @Operation(
+            summary = "Deactivate Card",
+            description = "Deactivates the card identified by the provided card number."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Card deactivated successfully"),
+            @ApiResponse(responseCode = "404", description = "Card not found"),
+            @ApiResponse(responseCode = "403", description = "Access denied")
+    })
+    public ResponseEntity<Void> deactivateCard(
+            @Parameter(
+                    description = "Card number to deactivate",
+                    in = ParameterIn.PATH,
+                    required = true,
+                    example = "1234123412341234"
+            )
+            @PathVariable String cardNumber) {
+        cardService.changeCardStatus(cardNumber, CardStatus.DEACTIVATED);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/dto/AccountDto.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/dto/AccountDto.java
@@ -1,0 +1,37 @@
+package rs.raf.bank_service.domain.dto;
+
+import lombok.Data;
+import rs.raf.bank_service.domain.enums.AccountStatus;
+
+import java.math.BigDecimal;
+
+@Data
+public class AccountDto {
+    private String accountNumber;
+    private Long clientId;
+    private Long companyId;
+    private Long createdByEmployeeId;
+
+    private String creationDate;
+    private String expirationDate;
+
+    private String currencyCode;
+
+    private AccountStatus status;
+
+    private BigDecimal balance;
+    private BigDecimal availableBalance;
+    private BigDecimal dailyLimit;
+    private BigDecimal monthlyLimit;
+    private BigDecimal dailySpending;
+    private BigDecimal monthlySpending;
+
+    private ClientDto owner;
+
+    // ("lični" ili "poslovni")
+    private String ownershipType;
+
+    // ("tekući" ili "devizni")
+    private String accountCategory;
+}
+

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/dto/CardDto.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/dto/CardDto.java
@@ -1,0 +1,23 @@
+package rs.raf.bank_service.domain.dto;
+
+
+import lombok.Data;
+import rs.raf.bank_service.domain.enums.CardStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+public class CardDto {
+    private Long id;
+    private String cardNumber;
+    private String cvv;
+    private LocalDate creationDate;
+    private LocalDate expirationDate;
+    private CardStatus status;
+    private BigDecimal cardLimit;
+
+    private ClientDto owner;
+
+    private String accountNumber;
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/dto/ClientDto.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/dto/ClientDto.java
@@ -1,0 +1,12 @@
+package rs.raf.bank_service.domain.dto;
+
+
+import lombok.Data;
+
+@Data
+public class ClientDto {
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private String email;
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/dto/EmailRequestDto.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/dto/EmailRequestDto.java
@@ -1,0 +1,8 @@
+package rs.raf.bank_service.domain.dto;
+import lombok.Data;
+
+@Data
+public class EmailRequestDto {
+    private String destination;
+    private String code;
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/dto/EmailRequestDto.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/dto/EmailRequestDto.java
@@ -1,4 +1,5 @@
 package rs.raf.bank_service.domain.dto;
+
 import lombok.Data;
 
 @Data

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/dto/UserDto.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/dto/UserDto.java
@@ -1,7 +1,6 @@
 package rs.raf.bank_service.domain.dto;
 
 import lombok.Data;
-import java.time.LocalDateTime;
 
 @Data
 public class UserDto {

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/entity/Account.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/entity/Account.java
@@ -24,7 +24,7 @@ import java.time.LocalDate;
 public abstract class Account {
     @Id
     // @Column(unique = true, length = 18)
-   // @GeneratedValue(strategy = GenerationType.IDENTITY)
+    // @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(updatable = false)
     private String accountNumber;
 

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/entity/Card.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/entity/Card.java
@@ -15,19 +15,19 @@ public class Card {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
+
     @Column(unique = true, length = 16)
     private String cardNumber;
-    
+
     private String cvv;
     private LocalDate creationDate;
     private LocalDate expirationDate;
-    
+
     @ManyToOne
     private Account account;
-    
+
     @Enumerated(EnumType.STRING)
     private CardStatus status;
-    
+
     private BigDecimal cardLimit;
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/entity/CompanyAccount.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/entity/CompanyAccount.java
@@ -1,7 +1,8 @@
 package rs.raf.bank_service.domain.entity;
 
-import lombok.*;
-import lombok.experimental.SuperBuilder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/entity/Currency.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/entity/Currency.java
@@ -1,9 +1,10 @@
 package rs.raf.bank_service.domain.entity;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/entity/PersonalAccount.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/entity/PersonalAccount.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 
@@ -13,6 +14,6 @@ import javax.persistence.Entity;
 @Setter
 @SuperBuilder
 @RequiredArgsConstructor
-public class PersonalAccount extends Account{
+public class PersonalAccount extends Account {
 
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/mapper/AccountMapper.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/mapper/AccountMapper.java
@@ -4,7 +4,6 @@ import rs.raf.bank_service.domain.dto.AccountDto;
 import rs.raf.bank_service.domain.dto.ClientDto;
 import rs.raf.bank_service.domain.entity.Account;
 import rs.raf.bank_service.domain.entity.CompanyAccount;
-import rs.raf.bank_service.domain.enums.AccountOwnerType;
 import rs.raf.bank_service.domain.enums.AccountType;
 
 public class AccountMapper {

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/mapper/AccountMapper.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/mapper/AccountMapper.java
@@ -1,0 +1,53 @@
+package rs.raf.bank_service.domain.mapper;
+
+import rs.raf.bank_service.domain.dto.AccountDto;
+import rs.raf.bank_service.domain.dto.ClientDto;
+import rs.raf.bank_service.domain.entity.Account;
+import rs.raf.bank_service.domain.entity.CompanyAccount;
+import rs.raf.bank_service.domain.enums.AccountOwnerType;
+import rs.raf.bank_service.domain.enums.AccountType;
+
+public class AccountMapper {
+
+    public static AccountDto toDto(Account account, ClientDto client) {
+        AccountDto dto = new AccountDto();
+        dto.setAccountNumber(account.getAccountNumber());
+        dto.setClientId(account.getClientId());
+        if (account instanceof CompanyAccount) {
+            dto.setCompanyId(((CompanyAccount) account).getCompanyId());
+        }
+        dto.setCreatedByEmployeeId(account.getCreatedByEmployeeId());
+        dto.setCreationDate(account.getCreationDate() != null ? account.getCreationDate().toString() : null);
+        dto.setExpirationDate(account.getExpirationDate() != null ? account.getExpirationDate().toString() : null);
+
+        if (account.getCurrency() != null) {
+            dto.setCurrencyCode(account.getCurrency().getCode());
+        }
+
+        dto.setStatus(account.getStatus());
+        dto.setBalance(account.getBalance());
+        dto.setAvailableBalance(account.getAvailableBalance());
+        dto.setDailyLimit(account.getDailyLimit());
+        dto.setMonthlyLimit(account.getMonthlyLimit());
+        dto.setDailySpending(account.getDailySpending());
+        dto.setMonthlySpending(account.getMonthlySpending());
+
+        dto.setOwner(client);
+
+        if (account instanceof CompanyAccount) {
+            dto.setOwnershipType("poslovni");
+        } else {
+            dto.setOwnershipType("licni");
+        }
+
+        if (account.getType() == AccountType.CURRENT) {
+            dto.setAccountCategory("tekuci");
+        } else if (account.getType() == AccountType.FOREIGN) {
+            dto.setAccountCategory("devizni");
+        } else {
+            dto.setAccountCategory("nepoznato");
+        }
+
+        return dto;
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/mapper/CardMapper.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/mapper/CardMapper.java
@@ -1,0 +1,22 @@
+package rs.raf.bank_service.domain.mapper;
+
+import rs.raf.bank_service.domain.dto.CardDto;
+import rs.raf.bank_service.domain.dto.ClientDto;
+import rs.raf.bank_service.domain.entity.Card;
+
+public class CardMapper {
+
+    public static CardDto toDto(Card card, ClientDto client) {
+        CardDto dto = new CardDto();
+        dto.setId(card.getId());
+        dto.setCardNumber(card.getCardNumber());
+        dto.setCvv(card.getCvv());
+        dto.setCreationDate(card.getCreationDate());
+        dto.setExpirationDate(card.getExpirationDate());
+        dto.setStatus(card.getStatus());
+        dto.setCardLimit(card.getCardLimit());
+        dto.setOwner(client);
+        dto.setAccountNumber(card.getAccount().getAccountNumber());
+        return dto;
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/exceptions/ClientNotFoundException.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/exceptions/ClientNotFoundException.java
@@ -2,6 +2,6 @@ package rs.raf.bank_service.exceptions;
 
 public class ClientNotFoundException extends RuntimeException {
     public ClientNotFoundException(Long id) {
-        super("Cannot find client with id: "+id);
+        super("Cannot find client with id: " + id);
     }
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/exceptions/CurrencyNotFoundException.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/exceptions/CurrencyNotFoundException.java
@@ -1,8 +1,8 @@
 package rs.raf.bank_service.exceptions;
 
-public class CurrencyNotFoundException extends RuntimeException{
+public class CurrencyNotFoundException extends RuntimeException {
     public CurrencyNotFoundException(String id) {
-        super("Cannot find currency with id: "+id);
+        super("Cannot find currency with id: " + id);
     }
 
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/repository/AccountRepository.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/repository/AccountRepository.java
@@ -1,7 +1,11 @@
 package rs.raf.bank_service.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import rs.raf.bank_service.domain.entity.Account;
 
-public interface AccountRepository extends JpaRepository<Account, Long> {
+import java.util.List;
+
+public interface AccountRepository extends JpaRepository<Account, Long>, JpaSpecificationExecutor<Account> {
+    List<Account> findByAccountNumber(String accountNumber);
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/repository/CardRepository.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/repository/CardRepository.java
@@ -1,0 +1,13 @@
+package rs.raf.bank_service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import rs.raf.bank_service.domain.entity.Card;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CardRepository extends JpaRepository<Card, Long> {
+    List<Card> findByAccount_AccountNumber(String accountNumber);
+
+    Optional<Card> findByCardNumber(String cardNumber);
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/security/JwtAuthenticationFilter.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/security/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -25,6 +26,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final Key secret = Keys.hmacShaKeyFor("si-2024-banka-3-tajni-kljuc-za-jwt-generisanje-tokena-mora-biti-512-bitova-valjda-je-dovoljno".getBytes());
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
@@ -43,7 +45,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     userDetails, null, authorities);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-              System.out.println("Authorities: " + SecurityContextHolder.getContext().getAuthentication().getAuthorities());
+            System.out.println("Authorities: " + SecurityContextHolder.getContext().getAuthentication().getAuthorities());
         }
 
         filterChain.doFilter(request, response);
@@ -57,6 +59,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         return null;
     }
+
     public boolean validateToken(String token) {
         try {
             getClaimsFromToken(token);
@@ -66,6 +69,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             return false;
         }
     }
+
     public Claims getClaimsFromToken(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(secret)

--- a/bank-service/src/main/java/rs/raf/bank_service/service/AccountService.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/service/AccountService.java
@@ -1,23 +1,39 @@
 package rs.raf.bank_service.service;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
+import rs.raf.bank_service.client.UserClient;
+import rs.raf.bank_service.domain.dto.AccountDto;
+import rs.raf.bank_service.domain.dto.ClientDto;
 import rs.raf.bank_service.domain.dto.NewBankAccountDto;
 import rs.raf.bank_service.domain.dto.UserDto;
 import rs.raf.bank_service.domain.entity.*;
 import rs.raf.bank_service.domain.enums.AccountOwnerType;
 import rs.raf.bank_service.domain.enums.AccountStatus;
 import rs.raf.bank_service.domain.enums.AccountType;
+import rs.raf.bank_service.domain.mapper.AccountMapper;
 import rs.raf.bank_service.exceptions.ClientNotFoundException;
 import rs.raf.bank_service.exceptions.CurrencyNotFoundException;
 import rs.raf.bank_service.repository.AccountRepository;
 import rs.raf.bank_service.repository.CurrencyRepository;
+import rs.raf.bank_service.specification.AccountSearchSpecification;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -26,6 +42,66 @@ public class AccountService {
     UserService userService;
     private final CurrencyRepository currencyRepository;
     private final AccountRepository accountRepository;
+
+    @Autowired
+    private final UserClient userClient;
+
+    @Operation(
+            summary = "Retrieve accounts with filtering and pagination",
+            description = "Returns a paginated list of accounts filtered by account number and owner's first and last name."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Accounts retrieved successfully"),
+            @ApiResponse(responseCode = "404", description = "No accounts found matching the criteria")
+    })
+    public Page<AccountDto> getAccounts(
+            @Parameter(
+                    description = "Filter accounts by part of the account number",
+                    example = "111111111111111111"
+            ) String accountNumber,
+            @Parameter(
+                    description = "Filter accounts by owner's first name",
+                    example = "Marko"
+            ) String firstName,
+            @Parameter(
+                    description = "Filter accounts by owner's last name",
+                    example = "Markovic"
+            ) String lastName,
+            Pageable pageable) {
+
+        Specification<Account> spec = Specification.where(AccountSearchSpecification.accountNumberContains(accountNumber));
+        List<Account> accounts = accountRepository.findAll(spec);
+
+        List<AccountDto> accountDtos = accounts.stream().map(account -> {
+            ClientDto client = userClient.getClientById(account.getClientId());
+            return AccountMapper.toDto(account, client);
+        }).collect(Collectors.toList());
+
+        if (firstName != null && !firstName.isEmpty()) {
+            accountDtos = accountDtos.stream()
+                    .filter(dto -> dto.getOwner() != null &&
+                            dto.getOwner().getFirstName() != null &&
+                            dto.getOwner().getFirstName().toLowerCase().contains(firstName.toLowerCase()))
+                    .collect(Collectors.toList());
+        }
+
+        if (lastName != null && !lastName.isEmpty()) {
+            accountDtos = accountDtos.stream()
+                    .filter(dto -> dto.getOwner() != null &&
+                            dto.getOwner().getLastName() != null &&
+                            dto.getOwner().getLastName().toLowerCase().contains(lastName.toLowerCase()))
+                    .collect(Collectors.toList());
+        }
+
+        accountDtos.sort(Comparator.comparing(dto ->
+                dto.getOwner() != null && dto.getOwner().getLastName() != null ?
+                        dto.getOwner().getLastName() : ""));
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), accountDtos.size());
+        List<AccountDto> pageContent = accountDtos.subList(start, end);
+        return new PageImpl<>(pageContent, pageable, accountDtos.size());
+    }
 
     public void createNewBankAccount(NewBankAccountDto newBankAccountDto, String authorizationHeader) {
         Long userId = newBankAccountDto.getClientId();

--- a/bank-service/src/main/java/rs/raf/bank_service/service/AccountService.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/service/AccountService.java
@@ -16,7 +16,10 @@ import rs.raf.bank_service.domain.dto.AccountDto;
 import rs.raf.bank_service.domain.dto.ClientDto;
 import rs.raf.bank_service.domain.dto.NewBankAccountDto;
 import rs.raf.bank_service.domain.dto.UserDto;
-import rs.raf.bank_service.domain.entity.*;
+import rs.raf.bank_service.domain.entity.Account;
+import rs.raf.bank_service.domain.entity.CompanyAccount;
+import rs.raf.bank_service.domain.entity.Currency;
+import rs.raf.bank_service.domain.entity.PersonalAccount;
 import rs.raf.bank_service.domain.enums.AccountOwnerType;
 import rs.raf.bank_service.domain.enums.AccountStatus;
 import rs.raf.bank_service.domain.enums.AccountType;
@@ -31,20 +34,18 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
 public class AccountService {
-    @Autowired
-    UserService userService;
     private final CurrencyRepository currencyRepository;
     private final AccountRepository accountRepository;
-
     @Autowired
     private final UserClient userClient;
+    @Autowired
+    UserService userService;
 
     @Operation(
             summary = "Retrieve accounts with filtering and pagination",

--- a/bank-service/src/main/java/rs/raf/bank_service/service/CardService.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/service/CardService.java
@@ -1,0 +1,77 @@
+package rs.raf.bank_service.service;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.AllArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+import rs.raf.bank_service.client.UserClient;
+import rs.raf.bank_service.domain.dto.CardDto;
+import rs.raf.bank_service.domain.dto.ClientDto;
+import rs.raf.bank_service.domain.dto.EmailRequestDto;
+import rs.raf.bank_service.domain.entity.Card;
+import rs.raf.bank_service.domain.enums.CardStatus;
+import rs.raf.bank_service.domain.mapper.CardMapper;
+import rs.raf.bank_service.repository.CardRepository;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class CardService {
+
+    private final CardRepository cardRepository;
+    private final UserClient userClient;
+    private final RabbitTemplate rabbitTemplate;
+
+
+    @Operation(
+            summary = "Retrieve cards by account",
+            description = "Returns a list of card DTOs associated with the provided account number."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Cards retrieved successfully"),
+            @ApiResponse(responseCode = "404", description = "No cards found for the given account")
+    })
+    public List<CardDto> getCardsByAccount(
+            @Parameter(description = "Account number to search for", example = "222222222222222222")
+            String accountNumber) {
+        List<Card> cards = cardRepository.findByAccount_AccountNumber(accountNumber);
+        return cards.stream().map(card -> {
+            ClientDto client = userClient.getClientById(card.getAccount().getClientId());
+            return CardMapper.toDto(card, client);
+        }).collect(Collectors.toList());
+    }
+
+    @Operation(
+            summary = "Change card status",
+            description = "Changes the status of a card identified by its card number and sends an email notification to the card owner."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Card status updated and notification sent successfully"),
+            @ApiResponse(responseCode = "404", description = "Card not found")
+    })
+    public void changeCardStatus(
+            @Parameter(description = "Card number", example = "1234123412341234")
+            String cardNumber,
+            @Parameter(description = "New status for the card", example = "BLOCKED")
+            CardStatus newStatus) {
+        Card card = cardRepository.findByCardNumber(cardNumber)
+                .orElseThrow(() -> new EntityNotFoundException("Card not found with number: " + cardNumber));
+
+        card.setStatus(newStatus);
+        cardRepository.save(card);
+
+        ClientDto owner = userClient.getClientById(card.getAccount().getClientId());
+
+        EmailRequestDto emailRequestDto = new EmailRequestDto();
+        emailRequestDto.setCode(newStatus.toString());
+        emailRequestDto.setDestination(owner.getEmail());
+
+        rabbitTemplate.convertAndSend("card-status-change", emailRequestDto);
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/service/UserService.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/service/UserService.java
@@ -3,19 +3,19 @@ package rs.raf.bank_service.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import org.springframework.stereotype.Service;
-import org.springframework.beans.factory.annotation.Value;
 import okhttp3.Response;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 import rs.raf.bank_service.domain.dto.UserDto;
 
 import java.io.IOException;
 
 @Service
 public class UserService {
+    private final OkHttpClient client;
     // ! !!  ! ! ! NE RADITI OVAKO, POGLEDATI client/UserClient KLASU !!! ! ! ! ! !  !  1 !!!!!!!
     @Value("http://localhost:8080/api/") // za sad hardcoded ovde
     private String USER_SERVICE_URL;
-    private final OkHttpClient client;
 
     public UserService() {
         this.client = new OkHttpClient();

--- a/bank-service/src/main/java/rs/raf/bank_service/specification/AccountSearchSpecification.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/specification/AccountSearchSpecification.java
@@ -1,0 +1,16 @@
+package rs.raf.bank_service.specification;
+
+import org.springframework.data.jpa.domain.Specification;
+import rs.raf.bank_service.domain.entity.Account;
+
+public class AccountSearchSpecification {
+
+    public static Specification<Account> accountNumberContains(String accountNumber) {
+        return (root, query, criteriaBuilder) -> {
+            if (accountNumber == null || accountNumber.isEmpty()) {
+                return criteriaBuilder.conjunction();
+            }
+            return criteriaBuilder.like(root.get("accountNumber"), "%" + accountNumber + "%");
+        };
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/utils/DummyAuthenticationFilter.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/utils/DummyAuthenticationFilter.java
@@ -1,0 +1,36 @@
+package rs.raf.bank_service.utils;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+/// Klasa koja nam sluzi kao dummy kredencijali za autorizaciju postavljen je kao addFilterBefore u SpringSecurityConfig klasi sluzi da bi mogli da testiramo pozive i da saljemo zahteve izmedju servisa
+/// SLUZI ISKLJUCIVO ZA TESTIRANJE
+
+@Component
+public class DummyAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        // Postavljamo dummy autentifikaciju samo ako nije već postavljena
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken("petar.p@example.com",
+                            "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwZXRhci5wQGV4YW1wbGUuY29tIiwicGVybWlzc2lvbnMiOlsiYWRtaW4iXSwidXNlcklkIjo0LCJpYXQiOjE3NDA5NDg1MjEsImV4cCI6MTc0MTAzNDkyMX0.J56e-ukYkcsfPIiFJSG5pE4d_zxFy-Qr6Vq9i8JNghNHwJ14dzNYL7QGTrBLlQ11UNc0aivIhjF_zrojW8kgUg",
+                            List.of(new SimpleGrantedAuthority("admin")));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/bank-service/src/main/resources/application.properties
+++ b/bank-service/src/main/resources/application.properties
@@ -6,10 +6,8 @@ spring.datasource.password=lozinka
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.h2.console.enabled=true
 spring.jpa.show-sql=true
-
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
-
 # RabbitMQ konfiguracija
 spring.rabbitmq.host=localhost
 spring.rabbitmq.port=5672

--- a/bank-service/src/test/java/rs/raf/bank_service/unit/AccountControllerTest.java
+++ b/bank-service/src/test/java/rs/raf/bank_service/unit/AccountControllerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @WebMvcTest(AccountController.class)
 class AccountControllerTest {
 

--- a/bank-service/src/test/java/rs/raf/bank_service/unit/AccountControllerTest.java
+++ b/bank-service/src/test/java/rs/raf/bank_service/unit/AccountControllerTest.java
@@ -1,26 +1,49 @@
 package rs.raf.bank_service.unit;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
 import rs.raf.bank_service.controller.AccountController;
+import rs.raf.bank_service.domain.dto.AccountDto;
+import rs.raf.bank_service.domain.dto.ClientDto;
 import rs.raf.bank_service.domain.dto.NewBankAccountDto;
 import rs.raf.bank_service.service.AccountService;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+@WebMvcTest(AccountController.class)
 class AccountControllerTest {
 
-    @Mock
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
     private AccountService accountService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @InjectMocks
     private AccountController accountController;
@@ -28,6 +51,36 @@ class AccountControllerTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @WithMockUser(authorities = "admin")
+    void testGetAccounts() throws Exception {
+        ClientDto clientDto = new ClientDto();
+        clientDto.setFirstName("Marko");
+        clientDto.setLastName("Markovic");
+
+        AccountDto accountDto = new AccountDto();
+        accountDto.setAccountNumber("123456789012345678");
+        accountDto.setOwner(clientDto);
+
+        List<AccountDto> accounts = Arrays.asList(accountDto);
+        Page<AccountDto> page = new PageImpl<>(accounts);
+
+        Mockito.when(accountService.getAccounts(anyString(), anyString(), anyString(), any()))
+                .thenReturn(page);
+
+        mockMvc.perform(get("/api/account")
+                        .param("accountNumber", "123456789012345678")
+                        .param("firstName", "Marko")
+                        .param("lastName", "Markovic")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].accountNumber").value("123456789012345678"))
+                .andExpect(jsonPath("$.content[0].owner.firstName").value("Marko"))
+                .andExpect(jsonPath("$.content[0].owner.lastName").value("Markovic"));
     }
 
     @Test

--- a/bank-service/src/test/java/rs/raf/bank_service/unit/AccountServiceTest.java
+++ b/bank-service/src/test/java/rs/raf/bank_service/unit/AccountServiceTest.java
@@ -1,29 +1,45 @@
 package rs.raf.bank_service.unit;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.MediaType;
+import rs.raf.bank_service.client.UserClient;
+import rs.raf.bank_service.domain.dto.AccountDto;
+import rs.raf.bank_service.domain.dto.ClientDto;
 import rs.raf.bank_service.domain.dto.NewBankAccountDto;
 import rs.raf.bank_service.domain.dto.UserDto;
 import rs.raf.bank_service.domain.entity.Account;
 import rs.raf.bank_service.domain.entity.Currency;
+import rs.raf.bank_service.domain.entity.PersonalAccount;
+import rs.raf.bank_service.domain.enums.AccountStatus;
+import rs.raf.bank_service.exceptions.ClientNotFoundException;
+import rs.raf.bank_service.exceptions.CurrencyNotFoundException;
 import rs.raf.bank_service.repository.AccountRepository;
 import rs.raf.bank_service.repository.CurrencyRepository;
 import rs.raf.bank_service.service.AccountService;
 import rs.raf.bank_service.service.UserService;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDate;
-import java.util.NoSuchElementException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 @ExtendWith(MockitoExtension.class)
 public class AccountServiceTest {
@@ -40,9 +56,169 @@ public class AccountServiceTest {
     @InjectMocks
     private AccountService accountService;
 
+    @Mock
+    private UserClient userClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testGetAccounts_noFilters_returnsAllSorted() {
+        // Pravimo tri dummy računa
+        PersonalAccount account1 = new PersonalAccount();
+        account1.setAccountNumber("123");
+        account1.setClientId(1L);
+
+        PersonalAccount account2 = new PersonalAccount();
+        account2.setAccountNumber("456");
+        account2.setClientId(2L);
+
+        PersonalAccount account3 = new PersonalAccount();
+        account3.setAccountNumber("789");
+        account3.setClientId(3L);
+
+        List<Account> accountList = List.of(account1, account2, account3);
+        when(accountRepository.findAll(ArgumentMatchers.<Specification<Account>>any())).thenReturn(accountList);
+
+        // Pravimo odgovarajuće ClientDto objekte
+        ClientDto client1 = new ClientDto();
+        client1.setFirstName("Marko");
+        client1.setLastName("Markovic");
+
+        ClientDto client2 = new ClientDto();
+        client2.setFirstName("Jovan");
+        client2.setLastName("Jovic");
+
+        ClientDto client3 = new ClientDto();
+        client3.setFirstName("Zoran");
+        client3.setLastName("Zoric");
+
+        when(userClient.getClientById(1L)).thenReturn(client1);
+        when(userClient.getClientById(2L)).thenReturn(client2);
+        when(userClient.getClientById(3L)).thenReturn(client3);
+
+        // Kreiramo Pageable - prvi page sa dovoljno velikom veličinom da obuhvati sve
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<AccountDto> result = accountService.getAccounts(null, null, null, pageable);
+
+        // Očekujemo da su rezultati sortirani po prezimenu u rastućem redosledu:
+        // "Jovic" < "Markovic" < "Zoric"
+        List<AccountDto> dtos = result.getContent();
+        assertEquals(3, dtos.size());
+        assertEquals("456", dtos.get(0).getAccountNumber());
+        assertEquals("123", dtos.get(1).getAccountNumber());
+        assertEquals("789", dtos.get(2).getAccountNumber());
+    }
+
+    @Test
+    public void testGetAccounts_filterByFirstName() {
+        // Pravimo dva računa
+        PersonalAccount account1 = new PersonalAccount();
+        account1.setAccountNumber("123");
+        account1.setClientId(1L);
+
+        PersonalAccount account2 = new PersonalAccount();
+        account2.setAccountNumber("456");
+        account2.setClientId(2L);
+
+        List<Account> accountList = List.of(account1, account2);
+        when(accountRepository.findAll(ArgumentMatchers.<Specification<Account>>any())).thenReturn(accountList);
+
+
+        // Postavljamo ClientDto objekte
+        ClientDto client1 = new ClientDto();
+        client1.setFirstName("Marko");
+        client1.setLastName("Markovic");
+
+        ClientDto client2 = new ClientDto();
+        client2.setFirstName("Jovan");
+        client2.setLastName("Jovic");
+
+        when(userClient.getClientById(1L)).thenReturn(client1);
+        when(userClient.getClientById(2L)).thenReturn(client2);
+
+        Pageable pageable = PageRequest.of(0, 10);
+        // Filtriramo po imenu koje sadrži "Mar"
+        Page<AccountDto> result = accountService.getAccounts(null, "Mar", null, pageable);
+        List<AccountDto> dtos = result.getContent();
+
+        // Očekujemo da samo račun sa imenom "Marko" bude vraćen
+        assertEquals(1, dtos.size());
+        assertEquals("Marko", dtos.get(0).getOwner().getFirstName());
+    }
+
+    @Test
+    public void testGetAccounts_filterByLastName() {
+        // Pravimo dva računa
+        PersonalAccount account1 = new PersonalAccount();
+        account1.setAccountNumber("123");
+        account1.setClientId(1L);
+
+        PersonalAccount account2 = new PersonalAccount();
+        account2.setAccountNumber("456");
+        account2.setClientId(2L);
+
+        List<Account> accountList = List.of(account1, account2);
+        when(accountRepository.findAll(ArgumentMatchers.<Specification<Account>>any())).thenReturn(accountList);
+
+
+        // Postavljamo ClientDto objekte
+        ClientDto client1 = new ClientDto();
+        client1.setFirstName("Marko");
+        client1.setLastName("Markovic");
+
+        ClientDto client2 = new ClientDto();
+        client2.setFirstName("Jovan");
+        client2.setLastName("Jovic");
+
+        when(userClient.getClientById(1L)).thenReturn(client1);
+        when(userClient.getClientById(2L)).thenReturn(client2);
+
+        Pageable pageable = PageRequest.of(0, 10);
+        // Filtriramo po prezimenu koje sadrži "vic"
+        Page<AccountDto> result = accountService.getAccounts(null, null, "vic", pageable);
+        List<AccountDto> dtos = result.getContent();
+
+        // Očekujemo da su oba računa vraćena jer oba prezimena sadrže "vic"
+        assertEquals(2, dtos.size());
+    }
+
+    @Test
+    public void testGetAccounts_pagination() {
+        // Kreiramo 5 računa
+        List<Account> accountList = new ArrayList<>();
+        for (long i = 1; i <= 5; i++) {
+            PersonalAccount account = new PersonalAccount();
+            account.setAccountNumber(String.valueOf(i));
+            account.setClientId(i);
+            accountList.add(account);
+        }
+        when(accountRepository.findAll(ArgumentMatchers.<Specification<Account>>any())).thenReturn(accountList);
+
+
+        // Kreiramo odgovarajuće ClientDto objekte sa različitim prezimenima radi sortiranja
+        for (long i = 1; i <= 5; i++) {
+            ClientDto client = new ClientDto();
+            client.setFirstName("First" + i);
+            client.setLastName("Last" + i);
+            when(userClient.getClientById(i)).thenReturn(client);
+        }
+
+        // Zatražimo page 1 (drugi page) sa veličinom stranice 2
+        Pageable pageable = PageRequest.of(1, 2);
+        Page<AccountDto> result = accountService.getAccounts(null, null, null, pageable);
+        List<AccountDto> dtos = result.getContent();
+
+        // Pošto se računi sortiraju po prezimenu (Last1, Last2, Last3, Last4, Last5),
+        // drugi page treba da sadrži 3. i 4. račun (prema sortiranju)
+        assertEquals(2, dtos.size());
+        assertEquals("3", dtos.get(0).getAccountNumber());
+        assertEquals("4", dtos.get(1).getAccountNumber());
+    }
     @Test
     public void testCreateNewBankAccount_Success() {
-        // Given
         NewBankAccountDto newBankAccountDto = new NewBankAccountDto();
         newBankAccountDto.setClientId(1L);
         newBankAccountDto.setAccountType("CURRENT");
@@ -57,34 +233,33 @@ public class AccountServiceTest {
         currency.setCode("EUR");
 
         when(userService.getUserById(1L, "Bearer token")).thenReturn(userDto);
+        // Use eq() to match the exact "EUR" string.
         when(currencyRepository.findByCode("EUR")).thenReturn(Optional.of(currency));
 
-        // When
         accountService.createNewBankAccount(newBankAccountDto, "Bearer token");
 
-        // Then
         verify(accountRepository, times(1)).save(any(Account.class));
     }
+
     @Test
     public void testCreateNewBankAccount_ClientNotFound() {
-        // Given
         NewBankAccountDto newBankAccountDto = new NewBankAccountDto();
-        newBankAccountDto.setClientId(999L); // Nepostojeći klijent
+        newBankAccountDto.setClientId(999L);
         newBankAccountDto.setAccountType("PERSONAL");
         newBankAccountDto.setCurrency("USD");
 
         when(userService.getUserById(999L, "Bearer token")).thenReturn(null);
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> {
+        Exception exception = assertThrows(ClientNotFoundException.class, () -> {
             accountService.createNewBankAccount(newBankAccountDto, "Bearer token");
         });
-
-        assertEquals("Client not found with ID: 999", exception.getMessage());
+        // Adjusted expected message:
+        assertEquals("Cannot find client with id: 999", exception.getMessage());
         verify(accountRepository, never()).save(any(Account.class));
     }
+
     @Test
     public void testCreateNewBankAccount_InvalidCurrency() {
-        // Given
         NewBankAccountDto newBankAccountDto = new NewBankAccountDto();
         newBankAccountDto.setClientId(1L);
         newBankAccountDto.setAccountType("PERSONAL");
@@ -94,14 +269,14 @@ public class AccountServiceTest {
         userDto.setId(1L);
 
         when(userService.getUserById(1L, "Bearer token")).thenReturn(userDto);
-        when(currencyRepository.findByCode("INVALID")).thenReturn(java.util.Optional.empty());
+        // Mark this stubbing as lenient to avoid unnecessary stubbing exception.
+        lenient().when(currencyRepository.findByCode("INVALID")).thenReturn(Optional.empty());
 
-        Exception exception = assertThrows(NoSuchElementException.class, () -> {
+        Exception exception = assertThrows(CurrencyNotFoundException.class, () -> {
             accountService.createNewBankAccount(newBankAccountDto, "Bearer token");
         });
-
-        assertEquals("Invalid currency.", exception.getMessage());
+        // Adjusted expected message:
+        assertEquals("Cannot find currency with id: INVALID", exception.getMessage());
         verify(accountRepository, never()).save(any(Account.class));
     }
-
 }

--- a/bank-service/src/test/java/rs/raf/bank_service/unit/AccountServiceTest.java
+++ b/bank-service/src/test/java/rs/raf/bank_service/unit/AccountServiceTest.java
@@ -1,9 +1,5 @@
 package rs.raf.bank_service.unit;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +8,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import rs.raf.bank_service.client.UserClient;
 import rs.raf.bank_service.domain.dto.AccountDto;
 import rs.raf.bank_service.domain.dto.ClientDto;
@@ -20,7 +20,6 @@ import rs.raf.bank_service.domain.dto.UserDto;
 import rs.raf.bank_service.domain.entity.Account;
 import rs.raf.bank_service.domain.entity.Currency;
 import rs.raf.bank_service.domain.entity.PersonalAccount;
-import rs.raf.bank_service.domain.enums.AccountStatus;
 import rs.raf.bank_service.exceptions.ClientNotFoundException;
 import rs.raf.bank_service.exceptions.CurrencyNotFoundException;
 import rs.raf.bank_service.repository.AccountRepository;
@@ -28,18 +27,14 @@ import rs.raf.bank_service.repository.CurrencyRepository;
 import rs.raf.bank_service.service.AccountService;
 import rs.raf.bank_service.service.UserService;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class AccountServiceTest {
@@ -217,6 +212,7 @@ public class AccountServiceTest {
         assertEquals("3", dtos.get(0).getAccountNumber());
         assertEquals("4", dtos.get(1).getAccountNumber());
     }
+
     @Test
     public void testCreateNewBankAccount_Success() {
         NewBankAccountDto newBankAccountDto = new NewBankAccountDto();

--- a/bank-service/src/test/java/rs/raf/bank_service/unit/CardControllerTest.java
+++ b/bank-service/src/test/java/rs/raf/bank_service/unit/CardControllerTest.java
@@ -1,0 +1,84 @@
+package rs.raf.bank_service.unit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import rs.raf.bank_service.controller.CardController;
+import rs.raf.bank_service.domain.dto.CardDto;
+import rs.raf.bank_service.domain.enums.CardStatus;
+import rs.raf.bank_service.service.CardService;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CardController.class)
+public class CardControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CardService cardService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(authorities = "admin")
+    public void testGetCardsByAccount() throws Exception {
+        CardDto cardDto = new CardDto();
+        cardDto.setId(1L);
+        cardDto.setCardNumber("1111222233334444");
+        cardDto.setStatus(CardStatus.ACTIVE);
+
+        List<CardDto> cards = Arrays.asList(cardDto);
+        Mockito.when(cardService.getCardsByAccount(Mockito.anyString())).thenReturn(cards);
+
+        mockMvc.perform(get("/api/accounts/123456789012345678/cards")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].cardNumber").value("1111222233334444"))
+                .andExpect(jsonPath("$[0].status").value("ACTIVE"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "admin")
+    public void testBlockCard() throws Exception {
+        Mockito.doNothing().when(cardService).changeCardStatus(String.valueOf(Mockito.eq(1L)), Mockito.eq(CardStatus.BLOCKED));
+
+        mockMvc.perform(post("/api/accounts/123456789012345678/cards/1/block")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "admin")
+    public void testUnblockCard() throws Exception {
+        Mockito.doNothing().when(cardService).changeCardStatus(String.valueOf(Mockito.eq(1L)), Mockito.eq(CardStatus.ACTIVE));
+
+        mockMvc.perform(post("/api/accounts/123456789012345678/cards/1/unblock")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "admin")
+    public void testDeactivateCard() throws Exception {
+        Mockito.doNothing().when(cardService).changeCardStatus(String.valueOf(Mockito.eq(1L)), Mockito.eq(CardStatus.DEACTIVATED));
+
+        mockMvc.perform(post("/api/accounts/123456789012345678/cards/1/deactivate")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+}

--- a/bank-service/src/test/java/rs/raf/bank_service/unit/CardServiceTest.java
+++ b/bank-service/src/test/java/rs/raf/bank_service/unit/CardServiceTest.java
@@ -1,0 +1,107 @@
+package rs.raf.bank_service.unit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import rs.raf.bank_service.client.UserClient;
+import rs.raf.bank_service.domain.dto.CardDto;
+import rs.raf.bank_service.domain.dto.ClientDto;
+import rs.raf.bank_service.domain.entity.Account;
+import rs.raf.bank_service.domain.entity.Card;
+import rs.raf.bank_service.domain.enums.CardStatus;
+import rs.raf.bank_service.repository.CardRepository;
+import rs.raf.bank_service.service.CardService;
+
+import javax.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CardServiceTest {
+
+    @Mock
+    private CardRepository cardRepository;
+
+    @Mock
+    private UserClient userClient;
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    @InjectMocks
+    private CardService cardService;
+
+    private Card dummyCard;
+    private Account dummyAccount;
+    private ClientDto dummyClient;
+
+    @BeforeEach
+    public void setUp() {
+        dummyAccount = new Account() {
+        };
+        dummyAccount.setAccountNumber("123456789012345678");
+        dummyAccount.setClientId(1L);
+
+        dummyCard = new Card();
+        dummyCard.setId(1L);
+        dummyCard.setCardNumber("1111222233334444");
+        dummyCard.setStatus(CardStatus.ACTIVE);
+        dummyCard.setAccount(dummyAccount);
+        dummyCard.setCreationDate(LocalDate.now());
+        dummyCard.setExpirationDate(LocalDate.now().plusYears(3));
+        dummyCard.setCardLimit(BigDecimal.valueOf(1000));
+
+        dummyClient = new ClientDto();
+        dummyClient.setId(1L);
+        dummyClient.setFirstName("Petar");
+        dummyClient.setLastName("Petrovic");
+        dummyClient.setEmail("petar@example.com");
+    }
+
+    @Test
+    public void testGetCardsByAccount() {
+        when(cardRepository.findByAccount_AccountNumber("123456789012345678"))
+                .thenReturn(Arrays.asList(dummyCard));
+        when(userClient.getClientById(1L)).thenReturn(dummyClient);
+
+        List<CardDto> result = cardService.getCardsByAccount("123456789012345678");
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("1111222233334444", result.get(0).getCardNumber());
+        assertEquals("Petar", result.get(0).getOwner().getFirstName());
+    }
+
+    @Test
+    public void testChangeCardStatus() {
+        when(cardRepository.findByCardNumber(dummyCard.getCardNumber()))
+                .thenReturn(Optional.of(dummyCard));
+        when(userClient.getClientById(dummyAccount.getClientId())).thenReturn(dummyClient);
+
+        cardService.changeCardStatus(dummyCard.getCardNumber(), CardStatus.BLOCKED);
+
+        assertEquals(CardStatus.BLOCKED, dummyCard.getStatus());
+        verify(cardRepository, times(1)).save(dummyCard);
+        verify(rabbitTemplate, times(1))
+                .convertAndSend(eq("card-status-change"), any(Object.class));
+    }
+
+    @Test
+    public void testChangeCardStatus_CardNotFound() {
+        when(cardRepository.findByCardNumber("nonExistingCard"))
+                .thenReturn(Optional.empty());
+
+        EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
+                () -> cardService.changeCardStatus("nonExistingCard", CardStatus.DEACTIVATED));
+        assertTrue(exception.getMessage().contains("Card not found"));
+    }
+}

--- a/email-service/src/main/java/rs/raf/email_service/EmailListener.java
+++ b/email-service/src/main/java/rs/raf/email_service/EmailListener.java
@@ -40,4 +40,12 @@ public class EmailListener {
         emailService.sendEmail(dto.getDestination(), subject, plain, content);
     }
 
+    @RabbitListener(queues = "card-status-change")
+    public void handleCardStatusChange(EmailRequestDto dto) throws MessagingException {
+        String subject = "Card Status Changed";
+        String content = "Your card status has been changed to: " + dto.getCode();
+        String plain = "Your card status is now: " + dto.getCode();
+        emailService.sendEmail(dto.getDestination(), subject, plain, content);
+    }
+
 }

--- a/email-service/src/main/java/rs/raf/email_service/EmailService.java
+++ b/email-service/src/main/java/rs/raf/email_service/EmailService.java
@@ -2,7 +2,6 @@ package rs.raf.email_service;
 
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-
 import org.springframework.stereotype.Service;
 
 import javax.mail.MessagingException;

--- a/email-service/src/main/java/rs/raf/email_service/configuration/RabbitMQConfig.java
+++ b/email-service/src/main/java/rs/raf/email_service/configuration/RabbitMQConfig.java
@@ -27,6 +27,11 @@ public class RabbitMQConfig {
     }
 
     @Bean
+    public Queue cardStatusChangeQueue() {
+        return new Queue("card-status-change", false);
+    }
+
+    @Bean
     public MessageConverter jsonMessageConverter() {
         return new Jackson2JsonMessageConverter();
     }

--- a/email-service/src/main/resources/application.properties
+++ b/email-service/src/main/resources/application.properties
@@ -6,7 +6,6 @@ spring.datasource.password=lozinka
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.h2.console.enabled=true
 spring.jpa.show-sql=true
-
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 #smtp

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/user-service/src/main/java/rs/raf/user_service/bootstrap/BootstrapData.java
+++ b/user-service/src/main/java/rs/raf/user_service/bootstrap/BootstrapData.java
@@ -38,7 +38,7 @@ public class BootstrapData implements CommandLineRunner {
             Permission employeePermission = Permission.builder()
                     .name("employee")
                     .build();
-            permissionRepository.saveAll(Set.of(adminPermission,employeePermission));
+            permissionRepository.saveAll(Set.of(adminPermission, employeePermission));
         }
 
         Set<Permission> permissions = new HashSet<>(permissionRepository.findAll());
@@ -107,7 +107,7 @@ public class BootstrapData implements CommandLineRunner {
 
             employeeRepository.saveAll(Set.of(employee, employee2));
         }
-        if(activityCodeRepository.count() == 0){
+        if (activityCodeRepository.count() == 0) {
             ActivityCode activityCode = ActivityCode.builder()
                     .id("10.01")
                     .description("Food producion")

--- a/user-service/src/main/java/rs/raf/user_service/configuration/SpringSecurityConfig.java
+++ b/user-service/src/main/java/rs/raf/user_service/configuration/SpringSecurityConfig.java
@@ -5,8 +5,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-
-
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,7 +15,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import rs.raf.user_service.security.JwtAuthenticationFilter;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
 import java.util.List;
 
 

--- a/user-service/src/main/java/rs/raf/user_service/controller/ClientController.java
+++ b/user-service/src/main/java/rs/raf/user_service/controller/ClientController.java
@@ -1,4 +1,5 @@
 package rs.raf.user_service.controller;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -12,19 +13,17 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.annotation.*;
-import rs.raf.user_service.dto.*;
+import rs.raf.user_service.dto.ClientDto;
+import rs.raf.user_service.dto.CreateClientDto;
+import rs.raf.user_service.dto.ErrorMessageDto;
+import rs.raf.user_service.dto.UpdateClientDto;
 import rs.raf.user_service.exceptions.EmailAlreadyExistsException;
 import rs.raf.user_service.exceptions.JmbgAlreadyExistsException;
-import rs.raf.user_service.exceptions.UserAlreadyExistsException;
 import rs.raf.user_service.service.ClientService;
 
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/admin/clients")

--- a/user-service/src/main/java/rs/raf/user_service/controller/CompanyController.java
+++ b/user-service/src/main/java/rs/raf/user_service/controller/CompanyController.java
@@ -7,17 +7,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import rs.raf.user_service.dto.CreateCompanyDto;
 import rs.raf.user_service.exceptions.ActivityCodeNotFoundException;
 import rs.raf.user_service.exceptions.ClientNotFoundException;
 import rs.raf.user_service.exceptions.CompanyRegNumExistsException;
 import rs.raf.user_service.exceptions.TaxIdAlreadyExistsException;
 import rs.raf.user_service.service.CompanyService;
-import rs.raf.user_service.service.EmployeeService;
-
-import javax.persistence.EntityNotFoundException;
 
 @RestController
 @RequestMapping("/api/company")

--- a/user-service/src/main/java/rs/raf/user_service/controller/EmployeeController.java
+++ b/user-service/src/main/java/rs/raf/user_service/controller/EmployeeController.java
@@ -12,11 +12,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.ObjectError;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import rs.raf.user_service.dto.*;
+import rs.raf.user_service.dto.CreateEmployeeDto;
+import rs.raf.user_service.dto.EmployeeDto;
+import rs.raf.user_service.dto.UpdateEmployeeDto;
 import rs.raf.user_service.exceptions.EmailAlreadyExistsException;
 import rs.raf.user_service.exceptions.JmbgAlreadyExistsException;
 import rs.raf.user_service.exceptions.UserAlreadyExistsException;
@@ -24,8 +23,6 @@ import rs.raf.user_service.service.EmployeeService;
 
 import javax.persistence.EntityNotFoundException;
 import javax.validation.Valid;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/admin/employees")
@@ -141,10 +138,9 @@ public class EmployeeController {
         try {
             EmployeeDto employeeDto = employeeService.createEmployee(createEmployeeDTO);
             return ResponseEntity.status(HttpStatus.CREATED).body(employeeDto);
-        }  catch(EmailAlreadyExistsException | UserAlreadyExistsException | JmbgAlreadyExistsException e) {
+        } catch (EmailAlreadyExistsException | UserAlreadyExistsException | JmbgAlreadyExistsException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
@@ -168,8 +164,7 @@ public class EmployeeController {
             return ResponseEntity.status(HttpStatus.OK).body(employeeDto);
         } catch (EntityNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }

--- a/user-service/src/main/java/rs/raf/user_service/dto/CreateCompanyDto.java
+++ b/user-service/src/main/java/rs/raf/user_service/dto/CreateCompanyDto.java
@@ -3,9 +3,6 @@ package rs.raf.user_service.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import rs.raf.user_service.entity.Client;
-
-import javax.persistence.*;
 
 @Getter
 @Setter

--- a/user-service/src/main/java/rs/raf/user_service/dto/UpdateClientDto.java
+++ b/user-service/src/main/java/rs/raf/user_service/dto/UpdateClientDto.java
@@ -8,7 +8,6 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import java.util.Date;
 
 @Getter
 @Setter

--- a/user-service/src/main/java/rs/raf/user_service/dto/UpdateClientDto.java
+++ b/user-service/src/main/java/rs/raf/user_service/dto/UpdateClientDto.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -15,6 +16,12 @@ import java.util.Date;
 
 
 public class UpdateClientDto {
+
+    @NotNull(message = "First name cannot be null")
+    @Size(min = 2, max = 100, message = "First name must be between 2 and 100 characters")
+    @Pattern(regexp = "^[a-zA-Z]+$", message = "First name must contain only letters")
+    private String firstName;
+
     @NotNull(message = "Last name cannot be null")
     @Size(min = 2, max = 100, message = "Last name must be between 2 and 100 characters")
     @Pattern(regexp = "^[a-zA-Z]+$", message = "First name must contain only letters")
@@ -30,4 +37,8 @@ public class UpdateClientDto {
 
     @NotNull(message = "Address cannot be null")
     private String address;
+
+    @NotNull(message = "Email cannot be null")
+    @Email(message = "Invalid email address")
+    private String email;
 }

--- a/user-service/src/main/java/rs/raf/user_service/entity/Company.java
+++ b/user-service/src/main/java/rs/raf/user_service/entity/Company.java
@@ -21,11 +21,11 @@ public class Company {
 
     private String name;
 
-    @Column(updatable = false,unique = true)
+    @Column(updatable = false, unique = true)
     private String registrationNumber;
 
-    @Column(updatable = false,unique = true)
-    private String  taxId;
+    @Column(updatable = false, unique = true)
+    private String taxId;
 
     private String activityCode;
 

--- a/user-service/src/main/java/rs/raf/user_service/entity/Employee.java
+++ b/user-service/src/main/java/rs/raf/user_service/entity/Employee.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
 import java.util.Date;
 
 @Entity

--- a/user-service/src/main/java/rs/raf/user_service/entity/Permission.java
+++ b/user-service/src/main/java/rs/raf/user_service/entity/Permission.java
@@ -2,7 +2,6 @@ package rs.raf.user_service.entity;
 
 import lombok.*;
 
-
 import javax.persistence.*;
 
 @Entity

--- a/user-service/src/main/java/rs/raf/user_service/exceptions/ActivityCodeNotFoundException.java
+++ b/user-service/src/main/java/rs/raf/user_service/exceptions/ActivityCodeNotFoundException.java
@@ -2,7 +2,7 @@ package rs.raf.user_service.exceptions;
 
 public class ActivityCodeNotFoundException extends RuntimeException {
     public ActivityCodeNotFoundException(Long id) {
-        super("Cannot find activity code with id: "+id);
+        super("Cannot find activity code with id: " + id);
     }
 
 }

--- a/user-service/src/main/java/rs/raf/user_service/exceptions/ClientNotFoundException.java
+++ b/user-service/src/main/java/rs/raf/user_service/exceptions/ClientNotFoundException.java
@@ -2,6 +2,6 @@ package rs.raf.user_service.exceptions;
 
 public class ClientNotFoundException extends RuntimeException {
     public ClientNotFoundException(Long id) {
-        super("Cannot find client with id: "+id);
+        super("Cannot find client with id: " + id);
     }
 }

--- a/user-service/src/main/java/rs/raf/user_service/exceptions/CompanyRegNumExistsException.java
+++ b/user-service/src/main/java/rs/raf/user_service/exceptions/CompanyRegNumExistsException.java
@@ -1,8 +1,8 @@
 package rs.raf.user_service.exceptions;
 
-public class CompanyRegNumExistsException extends RuntimeException{
+public class CompanyRegNumExistsException extends RuntimeException {
     public CompanyRegNumExistsException(String id) {
-        super("Company with registration number  "+id+" already exists.");
+        super("Company with registration number  " + id + " already exists.");
     }
 
 }

--- a/user-service/src/main/java/rs/raf/user_service/exceptions/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/rs/raf/user_service/exceptions/GlobalExceptionHandler.java
@@ -6,8 +6,6 @@ import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
-import rs.raf.user_service.dto.ErrorMessageDto;
 import rs.raf.user_service.dto.ValidationErrorMessageDto;
 
 import java.util.List;

--- a/user-service/src/main/java/rs/raf/user_service/exceptions/TaxIdAlreadyExistsException.java
+++ b/user-service/src/main/java/rs/raf/user_service/exceptions/TaxIdAlreadyExistsException.java
@@ -1,8 +1,8 @@
 package rs.raf.user_service.exceptions;
 
-public class TaxIdAlreadyExistsException extends RuntimeException{
+public class TaxIdAlreadyExistsException extends RuntimeException {
     public TaxIdAlreadyExistsException(String id) {
-        super("TaxId: "+id+" "+"already exits.");
+        super("TaxId: " + id + " " + "already exits.");
     }
 
 }

--- a/user-service/src/main/java/rs/raf/user_service/mapper/ClientMapper.java
+++ b/user-service/src/main/java/rs/raf/user_service/mapper/ClientMapper.java
@@ -61,10 +61,12 @@ public class ClientMapper {
     // ✅ Nova metoda: Ažuriranje entiteta na osnovu UpdateClientDTO
     public void fromUpdateDto(UpdateClientDto updateClientDTO, Client client) {
         if (updateClientDTO == null || client == null) return;
+        client.setFirstName(updateClientDTO.getFirstName());
         client.setLastName(updateClientDTO.getLastName());
         client.setAddress(updateClientDTO.getAddress());
         client.setPhone(updateClientDTO.getPhone());
         client.setGender(updateClientDTO.getGender());
+        client.setEmail(updateClientDTO.getEmail());
     }
 }
 

--- a/user-service/src/main/java/rs/raf/user_service/repository/ClientRepository.java
+++ b/user-service/src/main/java/rs/raf/user_service/repository/ClientRepository.java
@@ -1,12 +1,13 @@
 package rs.raf.user_service.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import rs.raf.user_service.entity.BaseUser;
 import rs.raf.user_service.entity.Client;
 
 import java.util.Optional;
 
-public interface ClientRepository extends JpaRepository<Client, Long> {
+public interface ClientRepository extends JpaRepository<Client, Long>, JpaSpecificationExecutor<Client> {
     Optional<Client> findByEmail(String email);
     Optional<Client> findByJmbg(String jmbg);
 

--- a/user-service/src/main/java/rs/raf/user_service/repository/ClientRepository.java
+++ b/user-service/src/main/java/rs/raf/user_service/repository/ClientRepository.java
@@ -2,13 +2,13 @@ package rs.raf.user_service.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import rs.raf.user_service.entity.BaseUser;
 import rs.raf.user_service.entity.Client;
 
 import java.util.Optional;
 
 public interface ClientRepository extends JpaRepository<Client, Long>, JpaSpecificationExecutor<Client> {
     Optional<Client> findByEmail(String email);
+
     Optional<Client> findByJmbg(String jmbg);
 
 }

--- a/user-service/src/main/java/rs/raf/user_service/repository/CompanyRepository.java
+++ b/user-service/src/main/java/rs/raf/user_service/repository/CompanyRepository.java
@@ -1,14 +1,13 @@
 package rs.raf.user_service.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import rs.raf.user_service.entity.AuthToken;
-import rs.raf.user_service.entity.Client;
 import rs.raf.user_service.entity.Company;
 
 import java.util.Optional;
 
 public interface CompanyRepository extends JpaRepository<Company, Long> {
     Optional<Company> findByRegistrationNumber(String registrationNumber);
+
     Optional<Company> findByTaxId(String taxId);
 
 }

--- a/user-service/src/main/java/rs/raf/user_service/service/CompanyService.java
+++ b/user-service/src/main/java/rs/raf/user_service/service/CompanyService.java
@@ -22,17 +22,17 @@ public class CompanyService {
     private final ClientRepository clientRepository;
     private final ActivityCodeRepository activityCodeRepository;
 
-    public void createCompany(CreateCompanyDto createCompanyDto){
+    public void createCompany(CreateCompanyDto createCompanyDto) {
         Client client = clientRepository.findById(createCompanyDto.getMajorityOwner()).orElse(null);
-        if(client == null)
+        if (client == null)
             throw new NoSuchElementException("Owner not found with ID: " + createCompanyDto.getMajorityOwner());
 
         ActivityCode activityCode = activityCodeRepository.findById(createCompanyDto.getActivityCode()).orElse(null);
-        if(activityCode == null)
+        if (activityCode == null)
             throw new NoSuchElementException("Activity code not found with ID: " + createCompanyDto.getActivityCode());
-        if(companyRepository.findByRegistrationNumber(createCompanyDto.getRegistrationNumber()).isPresent())
+        if (companyRepository.findByRegistrationNumber(createCompanyDto.getRegistrationNumber()).isPresent())
             throw new CompanyRegNumExistsException(createCompanyDto.getRegistrationNumber());
-        if(companyRepository.findByTaxId(createCompanyDto.getTaxId()).isPresent())
+        if (companyRepository.findByTaxId(createCompanyDto.getTaxId()).isPresent())
             throw new TaxIdAlreadyExistsException(createCompanyDto.getTaxId());
         Company company = new Company();
         company.setName(createCompanyDto.getName());

--- a/user-service/src/main/java/rs/raf/user_service/service/UserService.java
+++ b/user-service/src/main/java/rs/raf/user_service/service/UserService.java
@@ -1,16 +1,12 @@
 package rs.raf.user_service.service;
 
 import lombok.AllArgsConstructor;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import rs.raf.user_service.dto.PermissionDto;
 import rs.raf.user_service.dto.PermissionRequestDto;
 import rs.raf.user_service.entity.BaseUser;
 import rs.raf.user_service.entity.Permission;
 import rs.raf.user_service.mapper.PermissionMapper;
-import rs.raf.user_service.repository.AuthTokenRepository;
 import rs.raf.user_service.repository.PermissionRepository;
 import rs.raf.user_service.repository.UserRepository;
 

--- a/user-service/src/main/java/rs/raf/user_service/specification/ClientSearchSpecification.java
+++ b/user-service/src/main/java/rs/raf/user_service/specification/ClientSearchSpecification.java
@@ -1,0 +1,46 @@
+package rs.raf.user_service.specification;
+
+import org.springframework.data.jpa.domain.Specification;
+import rs.raf.user_service.entity.Client;
+
+public class ClientSearchSpecification {
+
+    //Pretraga po imenu
+    public static Specification<Client> firstNameContains(String firstName) {
+        return (root, query, criteriaBuilder) -> {
+            if (firstName == null || firstName.isEmpty()) {
+                return criteriaBuilder.conjunction();
+            }
+            return criteriaBuilder.like(
+                    criteriaBuilder.lower(root.get("firstName")),
+                    "%" + firstName.toLowerCase() + "%"
+            );
+        };
+    }
+
+    //Pretraga po prezimenu
+    public static Specification<Client> lastNameContains(String lastName) {
+        return (root, query, criteriaBuilder) -> {
+            if (lastName == null || lastName.isEmpty()) {
+                return criteriaBuilder.conjunction();
+            }
+            return criteriaBuilder.like(
+                    criteriaBuilder.lower(root.get("lastName")),
+                    "%" + lastName.toLowerCase() + "%"
+            );
+        };
+    }
+
+    //Pretrega po mailu
+    public static Specification<Client> emailContains(String email) {
+        return (root, query, criteriaBuilder) -> {
+            if (email == null || email.isEmpty()) {
+                return criteriaBuilder.conjunction();
+            }
+            return criteriaBuilder.like(
+                    criteriaBuilder.lower(root.get("email")),
+                    "%" + email.toLowerCase() + "%"
+            );
+        };
+    }
+}

--- a/user-service/src/test/java/rs/raf/user_service/integration/userservice/UserServiceTestsConfig.java
+++ b/user-service/src/test/java/rs/raf/user_service/integration/userservice/UserServiceTestsConfig.java
@@ -1,8 +1,6 @@
 package rs.raf.user_service.integration.userservice;
 
 import io.cucumber.spring.CucumberContextConfiguration;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @CucumberContextConfiguration

--- a/user-service/src/test/java/rs/raf/user_service/integration/userservice/controllers/UserControllerTestsSteps.java
+++ b/user-service/src/test/java/rs/raf/user_service/integration/userservice/controllers/UserControllerTestsSteps.java
@@ -15,14 +15,13 @@ public class UserControllerTestsSteps extends UserServiceTestsConfig {
 
 
     private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    private final UserControllerTestsState userControllerTestsState = new UserControllerTestsState();
     @Autowired
     ClientController clientController;
     @Autowired
     ObjectMapper objectMapper;
     String adminToken;
     ResultActions resultActions;
-    private final UserControllerTestsState userControllerTestsState = new UserControllerTestsState();
-
 
     @Given("an admin user is logged in")
     public void anAdminUserIsLoggedIn() {

--- a/user-service/src/test/java/rs/raf/user_service/unit/ClientControllerUnitTest.java
+++ b/user-service/src/test/java/rs/raf/user_service/unit/ClientControllerUnitTest.java
@@ -6,9 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.*;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -69,6 +67,8 @@ public class ClientControllerUnitTest {
         createClientDTO.setJmbg("1234567890123");
 
         updateClientDTO = new UpdateClientDto();
+        updateClientDTO.setFirstName(clientDTO.getFirstName());  // added if required by validation
+        updateClientDTO.setEmail(clientDTO.getEmail());
         updateClientDTO.setLastName("MarkovicUpdated");
         updateClientDTO.setAddress("Nova Adresa");
         updateClientDTO.setPhone("0611159999");
@@ -80,7 +80,8 @@ public class ClientControllerUnitTest {
         List<ClientDto> clients = Arrays.asList(clientDTO);
         Page<ClientDto> clientsPage = new PageImpl<>(clients);
 
-        when(clientService.listClients(PageRequest.of(0,10))).thenReturn(clientsPage);
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("lastName").ascending());
+        when(clientService.listClientsWithFilters(null, null, null, pageable)).thenReturn(clientsPage);
 
         mockMvc.perform(get("/api/admin/clients")
                         .param("page", "0")
@@ -89,7 +90,7 @@ public class ClientControllerUnitTest {
                 .andExpect(jsonPath("$.content", hasSize(1)))
                 .andExpect(jsonPath("$.content[0].firstName", is(clientDTO.getFirstName())));
 
-        verify(clientService, times(1)).listClients(PageRequest.of(0,10));
+        verify(clientService, times(1)).listClientsWithFilters(null, null, null, pageable);
     }
 
     @Test

--- a/user-service/src/test/java/rs/raf/user_service/unit/CompanyServiceTest.java
+++ b/user-service/src/test/java/rs/raf/user_service/unit/CompanyServiceTest.java
@@ -17,7 +17,8 @@ import rs.raf.user_service.service.CompanyService;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/user-service/src/test/java/rs/raf/user_service/unit/CompanyServiceTest.java
+++ b/user-service/src/test/java/rs/raf/user_service/unit/CompanyServiceTest.java
@@ -46,7 +46,7 @@ class CompanyServiceTest {
         CreateCompanyDto createCompanyDto = new CreateCompanyDto();
         createCompanyDto.setName("Test Company");
         createCompanyDto.setRegistrationNumber("12345");
-        createCompanyDto.setTaxId(Long.valueOf("67890"));
+        createCompanyDto.setTaxId(String.valueOf(Long.valueOf("67890")));
         createCompanyDto.setActivityCode(String.valueOf(1L));
         createCompanyDto.setAddress("Test Address");
         createCompanyDto.setMajorityOwner(1L);

--- a/user-service/src/test/java/rs/raf/user_service/unit/EmployeeControllerTest.java
+++ b/user-service/src/test/java/rs/raf/user_service/unit/EmployeeControllerTest.java
@@ -7,7 +7,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import rs.raf.user_service.controller.EmployeeController;
 import rs.raf.user_service.dto.CreateEmployeeDto;
 import rs.raf.user_service.dto.EmployeeDto;

--- a/user-service/src/test/java/rs/raf/user_service/unit/EmployeeServiceTest.java
+++ b/user-service/src/test/java/rs/raf/user_service/unit/EmployeeServiceTest.java
@@ -71,7 +71,7 @@ class EmployeeServiceTest {
 
         when(employeeRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
 
-        Page<EmployeeDto> result = employeeService.findAll("Jovan", "Jovanovic", "jovan456@example.com","Developer", PageRequest.of(0, 10));
+        Page<EmployeeDto> result = employeeService.findAll("Jovan", "Jovanovic", "jovan456@example.com", "Developer", PageRequest.of(0, 10));
 
         assertNotNull(result);
         assertEquals(1, result.getTotalElements());


### PR DESCRIPTION
Upravljanje racunima:
Implementiran endpoint za dobijanje svih racuna s mogucnoscu filtriranja

Kada se preuzimaju racuni, podaci o vlasniku se dopunjuju pozivom prema user-service (preko Feign klijenta) koristeci metodu getClientById.

Upravljanje karticama:

Endpoint-i za preuzimanje kartica po accountNumber i za promenu statusa kartice (blokiranje, deblokiranje, deaktivacija) su implementirani u CardControlleru.

U CardService metoda changeCardStatus sada prima karticni broj (String) i koristi metodu findByCardNumber za pretragu kartice. Nakon promene statusa, poziva se email notifikacija.
Nakon što se status kartice promeni, kreira se objekat EmailRequestDto s informacijama o novom statusu i email adresi vlasnika, te se poruka calje na RabbitMQ queue "card-status-change".

U email-service dodan je novi listener za queue "card-status-change", koji prima poruke i obrađuje slanje email-a.

Upravljanje userima:
Dodati opcioni filteri koji se prosledjuju kao query parametri u ClientController kao i uradjeno sortiranje klijenata po prezimenu
Dodata provera da li je mail i dalje unique u ClientService prilikom azuriranja klijenta