### PR TITLE
Implementacija Pregleda Racuna i Detalja Racuna

### DIFF
--- a/bank-service/pom.xml
+++ b/bank-service/pom.xml
@@ -10,7 +10,6 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>rs.raf</groupId>
     <artifactId>bank-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
 
@@ -36,11 +35,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-openfeign</artifactId>
-            <version>3.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -132,6 +126,38 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.12.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-openfeign-core</artifactId>
+            <version>3.0.3</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+            <version>3.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.aot</groupId>
+                    <artifactId>spring-aot</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>2021.0.3</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/bank-service/src/main/java/rs/raf/bank_service/client/UserClient.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/client/UserClient.java
@@ -3,15 +3,12 @@ package rs.raf.bank_service.client;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.PostMapping;
-import rs.raf.bank_service.domain.dto.CheckTokenDto;
-import rs.raf.bank_service.domain.dto.ClientDto;
-import rs.raf.bank_service.domain.dto.RequestCardDto;
-import rs.raf.bank_service.domain.dto.AuthorizedPersonelDto;
-import rs.raf.bank_service.domain.dto.ClientDto;
-import rs.raf.bank_service.domain.dto.CompanyDto;
+import rs.raf.bank_service.domain.dto.*;
 
 import java.util.List;
+
 
 /// Klasa koja sluzi za slanje HTTP poziva na userService
 @FeignClient(name = "user-service", url = "${user.service.url:http://localhost:8080}",fallbackFactory = UserClientFallbackFactory.class,decode404 = true)
@@ -20,6 +17,11 @@ public interface UserClient {
     @GetMapping("/api/admin/clients/{id}")
     ClientDto getClientById(@PathVariable("id") Long id);
 
+    @GetMapping("/api/admin/clients/me")
+    ClientDto getClient(@RequestHeader("Authorization") String authorizationHeader);
+
+    @GetMapping("/api/admin/company/{id}")
+    CompanyDto getCompanyById(@RequestHeader("Authorization") String authorizationHeader, @PathVariable("id") Long id);
     @PostMapping("/api/auth/request-card")
     void requestCard(RequestCardDto requestCardDto);
 

--- a/bank-service/src/main/java/rs/raf/bank_service/client/UserClientFallbackFactory.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/client/UserClientFallbackFactory.java
@@ -37,6 +37,16 @@ public class UserClientFallbackFactory implements FallbackFactory<UserClient> {
             public List<AuthorizedPersonelDto> getAuthorizedPersonnelByCompany(Long companyId) {
                 return Collections.emptyList();
             }
+
+            @Override
+            public ClientDto getClient(String authorizationHeader) {
+                throw new RuntimeException(cause);
+            }
+
+            @Override
+            public CompanyDto getCompanyById(String authorizationHeader, Long id) {
+                throw new RuntimeException(cause);
+            }
         };
     }
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/dto/AccountDetailsDto.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/dto/AccountDetailsDto.java
@@ -1,0 +1,33 @@
+package rs.raf.bank_service.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import rs.raf.bank_service.domain.enums.AccountType;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountDetailsDto {
+
+    //private String accountName;
+    private String accountNumber;
+    private String AccountOwner;
+    private AccountType accountType;
+    private BigDecimal availableBalance;
+    private BigDecimal reservedFunds;
+    private BigDecimal balance;
+
+    public AccountDetailsDto(String accountNumber, AccountType accountType, BigDecimal availableBalance, BigDecimal reservedFunds,
+                             BigDecimal balance){
+        this.accountNumber = accountNumber;
+        this.accountType = accountType;
+        this.availableBalance = availableBalance;
+        this.reservedFunds = reservedFunds;
+        this.balance = balance;
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/dto/CompanyAccountDetailsDto.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/dto/CompanyAccountDetailsDto.java
@@ -1,0 +1,26 @@
+package rs.raf.bank_service.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import rs.raf.bank_service.domain.enums.AccountType;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyAccountDetailsDto extends AccountDetailsDto{
+
+    private String companyName;
+    private String registrationNumber;
+    private String  taxId;
+    private String address;
+
+    public CompanyAccountDetailsDto(String accountNumber, AccountType accountType, BigDecimal availableBalance, BigDecimal reservedFunds,
+                                    BigDecimal balance){
+        super(accountNumber, accountType, availableBalance, reservedFunds, balance);
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/entity/CompanyAccount.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/entity/CompanyAccount.java
@@ -14,5 +14,4 @@ import javax.persistence.Entity;
 @RequiredArgsConstructor
 public class CompanyAccount extends Account {
     private Long companyId;
-
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/domain/mapper/AccountMapper.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/domain/mapper/AccountMapper.java
@@ -1,13 +1,16 @@
 package rs.raf.bank_service.domain.mapper;
 
+import rs.raf.bank_service.domain.dto.AccountDetailsDto;
 import org.springframework.stereotype.Component;
 import rs.raf.bank_service.domain.dto.AccountDto;
 import rs.raf.bank_service.domain.dto.AccountTypeDto;
 import rs.raf.bank_service.domain.dto.ClientDto;
+import rs.raf.bank_service.domain.dto.CompanyAccountDetailsDto;
 import rs.raf.bank_service.domain.entity.Account;
 import rs.raf.bank_service.domain.entity.CompanyAccount;
 import rs.raf.bank_service.domain.entity.PersonalAccount;
 import rs.raf.bank_service.domain.enums.AccountType;
+import java.math.BigDecimal;
 
 @Component
 public class AccountMapper {
@@ -52,6 +55,30 @@ public class AccountMapper {
         }
 
         return dto;
+    }
+
+    // ✅ Mapiranje iz Account u AccountDetailsDto (bez naziva vlasnika, to se setuje naknadno)
+    public static AccountDetailsDto toDetailsDto(Account account) {
+        if (account == null) return null;
+        return new AccountDetailsDto(
+                account.getAccountNumber(),
+                account.getType(),
+                account.getAvailableBalance(),
+                BigDecimal.ZERO,
+                account.getBalance()
+        );
+    }
+
+    // ✅ Mapiranje iz Account u AccountDetailsDto (bez naziva vlasnika, to se setuje naknadno)
+    public static CompanyAccountDetailsDto toCompanyDetailsDto(Account account) {
+        if (account == null) return null;
+        return new CompanyAccountDetailsDto(
+                account.getAccountNumber(),
+                account.getType(),
+                account.getAvailableBalance(),
+                BigDecimal.ZERO,
+                account.getBalance()
+        );
     }
 
     public AccountTypeDto toAccountTypeDto(Account account) {

--- a/bank-service/src/main/java/rs/raf/bank_service/exceptions/AccountNotFoundException.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/exceptions/AccountNotFoundException.java
@@ -1,0 +1,7 @@
+package rs.raf.bank_service.exceptions;
+
+public class AccountNotFoundException extends RuntimeException {
+    public AccountNotFoundException() {
+        super("Account not found");
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/exceptions/ClientNotAccountOwnerException.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/exceptions/ClientNotAccountOwnerException.java
@@ -1,0 +1,7 @@
+package rs.raf.bank_service.exceptions;
+
+public class ClientNotAccountOwnerException extends RuntimeException{
+    public ClientNotAccountOwnerException() {
+        super("Client sending request is not the account owner.");
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/exceptions/UserNotAClientException.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/exceptions/UserNotAClientException.java
@@ -1,0 +1,7 @@
+package rs.raf.bank_service.exceptions;
+
+public class UserNotAClientException extends RuntimeException{
+    public UserNotAClientException() {
+        super("User sending request is not a client.");
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/repository/AccountRepository.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/repository/AccountRepository.java
@@ -2,12 +2,16 @@ package rs.raf.bank_service.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.query.Param;
 import rs.raf.bank_service.domain.entity.Account;
 
 import java.util.List;
 import java.util.Optional;
 
+
 public interface AccountRepository extends JpaRepository<Account, Long>, JpaSpecificationExecutor<Account> {
+    List<Account> findAllByAccountNumber(String accountNumber);
+    List<Account> findAllByClientId(@Param("clientId")Long clientId);
     Optional<Account> findByAccountNumber(String accountNumber);
     List<Account> findByClientId(Long clientId);
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/repository/PayeeRepository.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/repository/PayeeRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 @Repository
 public interface PayeeRepository extends JpaRepository<Payee, Long> {
 
-    Optional<Payee> findByAccountNumberandCliendId(String accountNumber, Long clientId);
+    Optional<Payee> findByAccountNumberAndClientId(String accountNumber, Long clientId);
 
     List<Payee> findByClientId(Long clientId);
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/service/AccountService.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/service/AccountService.java
@@ -1,5 +1,6 @@
 package rs.raf.bank_service.service;
 
+import feign.FeignException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,20 +13,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import rs.raf.bank_service.client.UserClient;
-import rs.raf.bank_service.domain.dto.AccountDto;
-import rs.raf.bank_service.domain.dto.ClientDto;
-import rs.raf.bank_service.domain.dto.NewBankAccountDto;
-import rs.raf.bank_service.domain.dto.UserDto;
-import rs.raf.bank_service.domain.entity.Account;
-import rs.raf.bank_service.domain.entity.CompanyAccount;
-import rs.raf.bank_service.domain.entity.Currency;
-import rs.raf.bank_service.domain.entity.PersonalAccount;
+import rs.raf.bank_service.domain.dto.*;
+import rs.raf.bank_service.domain.entity.*;
 import rs.raf.bank_service.domain.enums.AccountOwnerType;
 import rs.raf.bank_service.domain.enums.AccountStatus;
 import rs.raf.bank_service.domain.enums.AccountType;
 import rs.raf.bank_service.domain.mapper.AccountMapper;
-import rs.raf.bank_service.exceptions.ClientNotFoundException;
-import rs.raf.bank_service.exceptions.CurrencyNotFoundException;
+import rs.raf.bank_service.exceptions.*;
 import rs.raf.bank_service.repository.AccountRepository;
 import rs.raf.bank_service.repository.CurrencyRepository;
 import rs.raf.bank_service.specification.AccountSearchSpecification;
@@ -34,6 +28,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
@@ -140,4 +135,64 @@ public class AccountService {
 
                 accountRepository.save(newAccount);
         }
+
+    public List<AccountDto> getAccounts(String authorizationHeader) {
+        try {
+            ClientDto clientDto = userClient.getClient(authorizationHeader);
+
+            return accountRepository.findAllByClientId(clientDto.getId()).stream().map(account ->
+                    AccountMapper.toDto(account, clientDto)).sorted(Comparator.comparing(AccountDto::getAvailableBalance,
+                    Comparator.nullsLast(Comparator.naturalOrder())).reversed()).collect(Collectors.toList());
+        } catch (FeignException.NotFound e){
+            throw new UserNotAClientException();
+        }
+    }
+
+    public AccountDetailsDto getAccountDetails(String authorizationHeader, String accountNumber) {
+        try {
+            ClientDto clientDto = userClient.getClient(authorizationHeader);
+            Account account = accountRepository.findByAccountNumber(accountNumber)
+                    .orElseThrow(AccountNotFoundException::new);
+
+            if (!clientDto.getId().equals(account.getClientId()))
+                throw new ClientNotAccountOwnerException();
+
+            AccountDetailsDto accountDetailsDto;
+
+            if (account.getAccountOwnerType() != AccountOwnerType.COMPANY){
+                accountDetailsDto =  AccountMapper.toDetailsDto(account);
+                accountDetailsDto.setAccountOwner(clientDto.getFirstName() + " " + clientDto.getLastName());
+            } else {
+                accountDetailsDto = AccountMapper.toCompanyDetailsDto(account);
+                CompanyAccountDetailsDto companyAccountDetailsDto = (CompanyAccountDetailsDto) accountDetailsDto;
+
+                CompanyAccount companyAccount = (CompanyAccount) account;
+                CompanyDto companyDto = userClient.getCompanyById(authorizationHeader, companyAccount.getCompanyId());
+
+                companyAccountDetailsDto.setCompanyName(companyDto.getName());
+                companyAccountDetailsDto.setRegistrationNumber(companyDto.getRegistrationNumber());
+                companyAccountDetailsDto.setTaxId(companyDto.getTaxId());
+                companyAccountDetailsDto.setAddress(companyDto.getAddress());
+            }
+            return accountDetailsDto;
+        } catch (FeignException.NotFound e){
+            throw new UserNotAClientException();
+        }
+    }
+
+    //Verovatno ce da ide u TransactionService ali ne znam jer nemam Transaction entitet
+    public void getAccountTransactions(String authorizationHeader, String accountNumber) {
+        try {
+            ClientDto clientDto = userClient.getClient(authorizationHeader);
+            Account account = accountRepository.findByAccountNumber(accountNumber)
+                    .orElseThrow(AccountNotFoundException::new);
+
+            if (!clientDto.getId().equals(account.getClientId()))
+                throw new ClientNotAccountOwnerException();
+
+            //Nemam entitet za transakciju tako da ovde stajem
+        } catch (FeignException.NotFound e){
+            throw new UserNotAClientException();
+        }
+    }
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/service/PayeeService.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/service/PayeeService.java
@@ -40,7 +40,7 @@ public class PayeeService {
 
     public PayeeDto create(PayeeDto dto, Long clientId) {
 
-        Optional<Payee> existingPayee = repository.findByAccountNumberandCliendId(dto.getAccountNumber(), clientId); //ispravljena metoda u PayeeRepository
+        Optional<Payee> existingPayee = repository.findByAccountNumberAndClientId(dto.getAccountNumber(), clientId); //ispravljena metoda u PayeeRepository
         if (existingPayee.isPresent()) {
             throw new DuplicatePayeeException(dto.getAccountNumber()); //baca ovu gresku samo ako se poklopi clientId i accountNumber, u ostalim slucajevima moze
         }

--- a/bank-service/src/test/java/rs/raf/bank_service/unit/AccountControllerTest.java
+++ b/bank-service/src/test/java/rs/raf/bank_service/unit/AccountControllerTest.java
@@ -20,6 +20,8 @@ import rs.raf.bank_service.controller.AccountController;
 import rs.raf.bank_service.domain.dto.AccountDto;
 import rs.raf.bank_service.domain.dto.ClientDto;
 import rs.raf.bank_service.domain.dto.NewBankAccountDto;
+import rs.raf.bank_service.exceptions.ClientNotAccountOwnerException;
+import rs.raf.bank_service.exceptions.UserNotAClientException;
 import rs.raf.bank_service.exceptions.ClientNotFoundException;
 import rs.raf.bank_service.exceptions.CurrencyNotFoundException;
 import rs.raf.bank_service.service.AccountService;
@@ -133,5 +135,63 @@ class AccountControllerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals(errorMessage, response.getBody());
         verify(accountService).createNewBankAccount(newBankAccountDto, authorizationHeader);
+    }
+
+    @Test
+    void testGetAccounts_Success() {
+        ResponseEntity<?> response = accountController.getAccounts("Bearer token");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(accountService).getAccounts("Bearer token");
+    }
+
+    @Test
+    void testGetAccounts_BadRequest() {
+        doThrow(new UserNotAClientException()).when(accountService).getAccounts("Bearer token");
+
+        ResponseEntity<?> response = accountController.getAccounts("Bearer token");
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("User sending request is not a client.", response.getBody());
+        verify(accountService).getAccounts("Bearer token");
+    }
+
+    @Test
+    void testGetAccounts_Failure() {
+        doThrow(new RuntimeException()).when(accountService).getAccounts("Bearer token");
+
+        ResponseEntity<?> response = accountController.getAccounts("Bearer token");
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(accountService).getAccounts("Bearer token");
+    }
+
+    @Test
+    void testGetAccountDetails_Success() {
+        ResponseEntity<?> response = accountController.getAccountDetails("Bearer token", "1");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(accountService).getAccountDetails("Bearer token", "1");
+    }
+
+    @Test
+    void testGetAccountDetails_BadRequest() {
+        doThrow(new ClientNotAccountOwnerException()).when(accountService).getAccountDetails("Bearer token", "1");
+
+        ResponseEntity<?> response = accountController.getAccountDetails("Bearer token", "1");
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Client sending request is not the account owner.", response.getBody());
+        verify(accountService).getAccountDetails("Bearer token", "1");
+    }
+
+    @Test
+    void testGetAccountDetails_Failure() {
+        doThrow(new RuntimeException()).when(accountService).getAccountDetails("Bearer token", "1");
+
+        ResponseEntity<?> response = accountController.getAccountDetails("Bearer token", "1");
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        verify(accountService).getAccountDetails("Bearer token", "1");
     }
 }

--- a/bank-service/src/test/java/rs/raf/bank_service/unit/PayeeServiceTest.java
+++ b/bank-service/src/test/java/rs/raf/bank_service/unit/PayeeServiceTest.java
@@ -67,7 +67,7 @@ public class PayeeServiceTest {
         payee.setAccountNumber("1234567890");
 
         // Ispravljeno: when se poziva na repository, a ne na Optional
-        when(repository.findByAccountNumberandCliendId(dto.getAccountNumber(), clientId)).thenReturn(Optional.empty());
+        when(repository.findByAccountNumberAndClientId(dto.getAccountNumber(), clientId)).thenReturn(Optional.empty());
         when(mapper.toEntity(dto)).thenReturn(payee);
         when(repository.save(payee)).thenReturn(payee);
         when(mapper.toDto(payee)).thenReturn(dto);
@@ -193,7 +193,7 @@ public class PayeeServiceTest {
         existingPayee.setAccountNumber("1234567890");
         existingPayee.setClientId(clientId);
 
-        when(repository.findByAccountNumberandCliendId(dto.getAccountNumber(), clientId)).thenReturn(Optional.of(existingPayee));
+        when(repository.findByAccountNumberAndClientId(dto.getAccountNumber(), clientId)).thenReturn(Optional.of(existingPayee));
 
         // Act & Assert
         assertThrows(DuplicatePayeeException.class, () -> service.create(dto, clientId));

--- a/user-service/src/main/java/rs/raf/user_service/controller/CompanyController.java
+++ b/user-service/src/main/java/rs/raf/user_service/controller/CompanyController.java
@@ -7,15 +7,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 import rs.raf.user_service.dto.CreateCompanyDto;
-import rs.raf.user_service.exceptions.ActivityCodeNotFoundException;
-import rs.raf.user_service.exceptions.ClientNotFoundException;
-import rs.raf.user_service.exceptions.CompanyRegNumExistsException;
-import rs.raf.user_service.exceptions.TaxIdAlreadyExistsException;
+import rs.raf.user_service.exceptions.*;
 import rs.raf.user_service.service.CompanyService;
 
 @RestController
@@ -40,6 +35,25 @@ public class CompanyController {
         } catch (ClientNotFoundException | ActivityCodeNotFoundException | CompanyRegNumExistsException |
                  TaxIdAlreadyExistsException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "Get company", description = "Retrieves company by id")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved company"),
+            @ApiResponse(responseCode = "404", description = "Company not found."),
+            @ApiResponse(responseCode = "500", description = "Company retrieval failed.")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getCompanyById(@PathVariable("id") Long id) {
+        try {
+            return ResponseEntity.ok().body(companyService.getCompanyById(id));
+        } catch (CompanyNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        } catch (RuntimeException e){
+            return ResponseEntity.internalServerError().body(e.getMessage());
         }
 
     }

--- a/user-service/src/main/java/rs/raf/user_service/dto/CompanyDto.java
+++ b/user-service/src/main/java/rs/raf/user_service/dto/CompanyDto.java
@@ -1,22 +1,20 @@
-package rs.raf.bank_service.domain.dto;
+package rs.raf.user_service.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.Data;
+import rs.raf.user_service.entity.Client;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Data
 public class CompanyDto {
     private Long id;
     private String name;
     private String registrationNumber;
-    private String taxId;
+    private String  taxId;
     private String activityCode;
     private String address;
-    private ClientDto majorityOwner;
 }

--- a/user-service/src/main/java/rs/raf/user_service/exceptions/CompanyNotFoundException.java
+++ b/user-service/src/main/java/rs/raf/user_service/exceptions/CompanyNotFoundException.java
@@ -1,0 +1,7 @@
+package rs.raf.user_service.exceptions;
+
+public class CompanyNotFoundException extends RuntimeException{
+    public CompanyNotFoundException(Long id) {
+        super("Cannot find company with id: "+id);
+    }
+}

--- a/user-service/src/main/java/rs/raf/user_service/mapper/CompanyMapper.java
+++ b/user-service/src/main/java/rs/raf/user_service/mapper/CompanyMapper.java
@@ -1,0 +1,22 @@
+package rs.raf.user_service.mapper;
+
+import org.springframework.stereotype.Component;
+import rs.raf.user_service.dto.CompanyDto;
+import rs.raf.user_service.entity.Company;
+
+@Component
+public class CompanyMapper {
+
+    // ✅ Mapiranje iz Company u CompanyDto (sa svim poljima)
+    public static CompanyDto toDto(Company company) {
+        if (company == null) return null;
+        return new CompanyDto(
+                company.getId(),
+                company.getName(),
+                company.getRegistrationNumber(),
+                company.getTaxId(),
+                company.getActivityCode(),
+                company.getAddress()
+        );
+    }
+}

--- a/user-service/src/main/java/rs/raf/user_service/service/CompanyService.java
+++ b/user-service/src/main/java/rs/raf/user_service/service/CompanyService.java
@@ -2,12 +2,15 @@ package rs.raf.user_service.service;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import rs.raf.user_service.dto.CompanyDto;
 import rs.raf.user_service.dto.CreateCompanyDto;
 import rs.raf.user_service.entity.ActivityCode;
 import rs.raf.user_service.entity.Client;
 import rs.raf.user_service.entity.Company;
+import rs.raf.user_service.exceptions.CompanyNotFoundException;
 import rs.raf.user_service.exceptions.CompanyRegNumExistsException;
 import rs.raf.user_service.exceptions.TaxIdAlreadyExistsException;
+import rs.raf.user_service.mapper.CompanyMapper;
 import rs.raf.user_service.repository.ActivityCodeRepository;
 import rs.raf.user_service.repository.ClientRepository;
 import rs.raf.user_service.repository.CompanyRepository;
@@ -44,4 +47,12 @@ public class CompanyService {
 
         companyRepository.save(company);
     }
+
+    public CompanyDto getCompanyById(Long id){
+        Company company = companyRepository.findById(id)
+                .orElseThrow(() -> new CompanyNotFoundException(id));
+        return CompanyMapper.toDto(company);
+    }
+
+
 }


### PR DESCRIPTION
Novi PR za ovo jer nmg da resim konflikte na starom PR iz nekog razloga #68 

Implementiran prikaz racuna (ali vidim da je neki kolega vec slicno implementirao ali sa filterima). Implementiran prikaz detalja racuna po broju racuna ali s obzirom da je kolega prosirio AccountDto verovatno to nije potrebno vise jer se sad svi ti detalji dovataju svakako i sa dohvatanjem liste racuna. Implementacija dohvatanja Tranzakcija racuna nije moguca jer nemam entiter Tranzakcija pa ne znam kako bi to uradio (nzm da li je to propust ili kasni). Ja sam implementirao tako da se client za koga se dohvataju racuni, preko Authorization Headera dohvata a ne da se explicitno u request-u navodi client. Kroz moje iskustvo znam da je ovo mnogo bezbedniji nacin jer tako se onemogucuje da neki drugi client (sa ispravnim tokenom) dohvata informacije drugog klijenta. Naravno moze da se i eksplicitno navede client u request-u pa da se kroz Authorization Header provera da li je to isti client ali to je nepotreban korak. Moj savet je da se kod svih poziva radi jedno ili drugo. Isto tako je pametno kao sto sam ja, da se provarava da li je client koji salje zahtev taj koji je vlasnik racuna (to sam implementirao u dohvatanju detalja racuna, getAccountDetails). Svi testovi moji prolaze, testovi od kolega neki ne.