### PR TITLE
izracunavanje rate

### DIFF
--- a/bank-service/src/main/java/rs/raf/bank_service/exceptions/UnkownLoanTypeException.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/exceptions/UnkownLoanTypeException.java
@@ -1,0 +1,7 @@
+package rs.raf.bank_service.exceptions;
+
+public class UnkownLoanTypeException extends  RuntimeException{
+    public UnkownLoanTypeException() {
+        super("Unkown loan type");
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/repository/LoanRepository.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/repository/LoanRepository.java
@@ -3,8 +3,12 @@ package rs.raf.bank_service.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import rs.raf.bank_service.domain.entity.Loan;
+import rs.raf.bank_service.domain.enums.LoanStatus;
+
+import java.util.List;
 
 @Repository
 public interface LoanRepository extends JpaRepository<Loan, Long> {
+    List<Loan> findByStatus(LoanStatus loanStatus);
     // Možemo dodati custom metode ako su potrebne
 }

--- a/bank-service/src/main/java/rs/raf/bank_service/service/LoanService.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/service/LoanService.java
@@ -77,16 +77,9 @@ public class LoanService {
                 .account(loanRequest.getAccount())
                 .build();
 
-        /*
-        Loan loan = loanRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Loan with ID " + id + " not found"));
 
-        loan.setStatus(LoanStatus.APPROVED);
 
         loanRepository.save(loan);
-
-         */
-
         return loanMapper.toDto(loan);
     }
 

--- a/bank-service/src/main/java/rs/raf/bank_service/service/LoanService.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/service/LoanService.java
@@ -4,25 +4,35 @@ import org.springframework.stereotype.Service;
 import rs.raf.bank_service.domain.dto.LoanDto;
 import rs.raf.bank_service.domain.dto.LoanShortDto;
 import rs.raf.bank_service.domain.entity.Loan;
+import rs.raf.bank_service.domain.entity.LoanRequest;
 import rs.raf.bank_service.domain.enums.LoanStatus;
 import rs.raf.bank_service.exceptions.CurrencyNotFoundException;
 import rs.raf.bank_service.mappers.LoanMapper;
 import rs.raf.bank_service.repository.CurrencyRepository;
 import rs.raf.bank_service.repository.LoanRepository;
+import rs.raf.bank_service.repository.LoanRequestRepository;
+import rs.raf.bank_service.specification.LoanInterestRateCalculator;
+import rs.raf.bank_service.specification.LoanRateCalculator;
 
 import javax.persistence.EntityNotFoundException;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class LoanService {
     private final LoanRepository loanRepository;
+
+    private final LoanRequestRepository loanRequestRepository;
     private final LoanMapper loanMapper;
+
 
     private final CurrencyRepository currencyRepository;
 
-    public LoanService(LoanRepository loanRepository, LoanMapper loanMapper, CurrencyRepository currencyRepository) {
+    public LoanService(LoanRepository loanRepository, LoanRequestRepository loanRequestRepository, LoanMapper loanMapper, CurrencyRepository currencyRepository) {
         this.loanRepository = loanRepository;
+        this.loanRequestRepository = loanRequestRepository;
         this.loanMapper = loanMapper;
         this.currencyRepository = currencyRepository;
     }
@@ -42,11 +52,40 @@ public class LoanService {
     }
 
     public LoanDto approveLoan(Long id) {
+        // prema specifikaciji vadimo podatke iz loanRequest?
+
+        LoanRequest loanRequest = loanRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Loan request with ID " + id + " not found"));
+
+        Loan loan = Loan.builder()
+                .loanNumber(UUID.randomUUID().toString())
+                .type(loanRequest.getType())
+                .amount(loanRequest.getAmount())
+                .repaymentPeriod(loanRequest.getRepaymentPeriod())
+                .nominalInterestRate(LoanInterestRateCalculator.calculateNominalRate(loanRequest))
+                .effectiveInterestRate(LoanInterestRateCalculator.calculateEffectiveRate(loanRequest))
+                .startDate(LocalDate.now())
+                .dueDate(LocalDate.now().plusMonths(loanRequest.getRepaymentPeriod()))
+                .nextInstallmentAmount(LoanRateCalculator.calculateMonthlyRate(
+                        loanRequest.getAmount(),
+                        LoanInterestRateCalculator.calculateEffectiveRate(loanRequest),
+                        loanRequest.getRepaymentPeriod()))
+                .nextInstallmentDate(LocalDate.now().plusMonths(1))
+                .remainingDebt(loanRequest.getAmount())
+                .currency(loanRequest.getCurrency())
+                .status(LoanStatus.APPROVED)
+                .account(loanRequest.getAccount())
+                .build();
+
+        /*
         Loan loan = loanRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Loan with ID " + id + " not found"));
 
         loan.setStatus(LoanStatus.APPROVED);
+
         loanRepository.save(loan);
+
+         */
 
         return loanMapper.toDto(loan);
     }

--- a/bank-service/src/main/java/rs/raf/bank_service/specification/LoanInterestRateCalculator.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/specification/LoanInterestRateCalculator.java
@@ -1,0 +1,45 @@
+package rs.raf.bank_service.specification;
+
+import rs.raf.bank_service.domain.entity.LoanRequest;
+import rs.raf.bank_service.domain.enums.LoanType;
+import rs.raf.bank_service.exceptions.UnkownLoanTypeException;
+
+import java.math.BigDecimal;
+
+public class LoanInterestRateCalculator {
+
+    public static BigDecimal calculateNominalRate(LoanRequest request) {
+        return getBaseRate(request.getAmount());
+    }
+
+    public static BigDecimal calculateEffectiveRate(LoanRequest request) {
+        return getBaseRate(request.getAmount()).add(getMarginByLoanType(request.getType()));
+    }
+
+    private static BigDecimal getBaseRate(BigDecimal amount) {
+        if (amount.compareTo(new BigDecimal("500000")) <= 0) return new BigDecimal("6.25");
+        if (amount.compareTo(new BigDecimal("1000000")) <= 0) return new BigDecimal("6.00");
+        if (amount.compareTo(new BigDecimal("2000000")) <= 0) return new BigDecimal("5.75");
+        if (amount.compareTo(new BigDecimal("5000000")) <= 0) return new BigDecimal("5.50");
+        if (amount.compareTo(new BigDecimal("10000000")) <= 0) return new BigDecimal("5.25");
+        if (amount.compareTo(new BigDecimal("20000000")) <= 0) return new BigDecimal("5.00");
+        return new BigDecimal("4.75");
+    }
+
+    private static BigDecimal getMarginByLoanType(LoanType type) {
+        switch (type) {
+            case CASH:
+                return new BigDecimal("1.75");
+            case MORTGAGE:
+                return new BigDecimal("1.50");
+            case AUTO:
+                return new BigDecimal("1.25");
+            case REFINANCING:
+                return new BigDecimal("1.00");
+            case STUDENT:
+                return new BigDecimal("0.75");
+            default:
+                throw new UnkownLoanTypeException();
+        }
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/specification/LoanRateCalculator.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/specification/LoanRateCalculator.java
@@ -1,0 +1,12 @@
+package rs.raf.bank_service.specification;
+
+import java.math.BigDecimal;
+
+public class LoanRateCalculator {
+    public static BigDecimal calculateMonthlyRate(BigDecimal principal, BigDecimal annualRate, int months) {
+        BigDecimal monthlyRate = annualRate.divide(new BigDecimal("12"), 6, BigDecimal.ROUND_HALF_UP);
+        BigDecimal onePlusRPowerN = monthlyRate.add(BigDecimal.ONE).pow(months);
+        return principal.multiply(monthlyRate.multiply(onePlusRPowerN))
+                .divide(onePlusRPowerN.subtract(BigDecimal.ONE), 2, BigDecimal.ROUND_HALF_UP);
+    }
+}

--- a/bank-service/src/main/java/rs/raf/bank_service/specification/LoanScheduler.java
+++ b/bank-service/src/main/java/rs/raf/bank_service/specification/LoanScheduler.java
@@ -1,0 +1,48 @@
+package rs.raf.bank_service.specification;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import rs.raf.bank_service.domain.entity.Loan;
+import rs.raf.bank_service.domain.entity.LoanRequest;
+import rs.raf.bank_service.domain.enums.InterestRateType;
+import rs.raf.bank_service.domain.enums.LoanStatus;
+import rs.raf.bank_service.repository.LoanRepository;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Random;
+
+@Component
+public class LoanScheduler {
+
+    private final LoanRepository loanRepository;
+    private final Random random = new Random();
+
+    public LoanScheduler(LoanRepository loanRepository) {
+        this.loanRepository = loanRepository;
+    }
+
+    @Scheduled(cron = "0 0 1 * * ?")  // Svakog meseca
+    public void updateVariableInterestRates() {
+        List<Loan> loans = loanRepository.findByStatus(LoanStatus.APPROVED);
+
+        for (Loan loan : loans) {
+            if (loan.getInterestRateType() == InterestRateType.VARIABLE) {
+                BigDecimal adjustment = BigDecimal.valueOf(random.nextDouble() * 3 - 1.5); // -1.50% do +1.50%
+
+
+                loan.setNominalInterestRate(loan.getNominalInterestRate().add(adjustment));
+
+                //temp da bih izbegao da menjam celu metodu
+                LoanRequest tempRequest = new LoanRequest();
+                tempRequest.setAmount(loan.getAmount());
+                tempRequest.setType(loan.getType());
+
+
+                loan.setEffectiveInterestRate(LoanInterestRateCalculator.calculateEffectiveRate(tempRequest));
+
+                loanRepository.save(loan);
+            }
+        }
+    }
+}


### PR DESCRIPTION
 **LoanInterestRateCalculator**

calculateNominalRate(LoanRequest request) – vraća osnovnu (nominalnu) kamatnu stopu na osnovu iznosa kredita.
calculateEffectiveRate(LoanRequest request) – dodaje maržu banke na nominalnu stopu kako bi dobili efektivnu kamatu.
getBaseRate(BigDecimal amount) – određuje osnovnu kamatnu stopu prema tabeli iz specifikacije.
getMarginByLoanType(LoanType type) – vraća maržu banke zavisno od tipa kredita.

 **LoanRateCalculator**

calculateMonthlyRate(BigDecimal principal, BigDecimal annualRate, int months) – koristi standardnu kreditnu formulu za obračun mesečne rate.
Kamatna stopa se deli na 12 meseci i koristi se eksponencijalna formula za anuitetno izračunavanje rata.

**LoanScheduler**
updateVariableInterestRates() – pokreće se svakog meseca i primenjuje nasumičan pomeraj kamatne stope u rasponu [-1.50%, +1.50%].
