### PR TITLE
Implementirani endpointi za OTC portal: setovanje public amount-a i l…

### DIFF
--- a/stock-service/src/main/java/rs/raf/stock_service/controller/PortfolioController.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/controller/PortfolioController.java
@@ -7,11 +7,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import rs.raf.stock_service.domain.dto.PortfolioEntryDto;
+import rs.raf.stock_service.domain.dto.PublicStockDto;
+import rs.raf.stock_service.domain.dto.SetPublicAmountDto;
 import rs.raf.stock_service.service.PortfolioService;
 import rs.raf.stock_service.utils.JwtTokenUtil;
 
@@ -43,6 +42,58 @@ public class PortfolioController {
             List<PortfolioEntryDto> portfolio = portfolioService.getPortfolioForUser(userId);
 
             return ResponseEntity.ok(portfolio);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
+
+    @Operation(
+            summary = "Set public amount for a specific stock in user's portfolio",
+            description = "Allows CLIENT, AGENT, and SUPERVISOR roles to set the number of shares marked as public for a specific listing."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Public amount updated successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid input or user doesn't own the specified listing."),
+            @ApiResponse(responseCode = "403", description = "Access denied – only CLIENT, AGENT and SUPERVISOR roles allowed."),
+            @ApiResponse(responseCode = "500", description = "Unexpected server error.")
+    })
+    @PreAuthorize("hasAnyRole('CLIENT', 'AGENT')")
+    @PutMapping("/public-amount")
+    public ResponseEntity<?> setPublicAmount(@RequestHeader("Authorization") String authHeader,
+                                             @RequestBody SetPublicAmountDto dto) {
+        try {
+            Long userId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
+            portfolioService.setPublicAmount(userId, dto);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Server error: " + e.getMessage());
+        }
+    }
+
+    @Operation(
+            summary = "Get all public stocks (OTC portal)",
+            description = "Returns all STOCK type securities from all users that are marked as public (publicAmount > 0). Accessible to CLIENT, AGENT, SUPERVISOR and ADMIN."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Public stocks retrieved successfully."),
+            @ApiResponse(responseCode = "204", description = "No public stocks available."),
+            @ApiResponse(responseCode = "403", description = "Access denied – only CLIENT, AGENT, SUPERVISOR and ADMIN roles allowed."),
+            @ApiResponse(responseCode = "500", description = "Unexpected server error.")
+    })
+    @PreAuthorize("hasAnyRole('CLIENT', 'AGENT', 'SUPERVISOR', 'ADMIN')")
+    @GetMapping("/public-stocks")
+    public ResponseEntity<?> getAllPublicStocks() {
+        try {
+            List<PublicStockDto> result = portfolioService.getAllPublicStocks();
+
+            if (result.isEmpty()) {
+                return ResponseEntity.noContent().build();
+            }
+
+            return ResponseEntity.ok(result);
+
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/dto/PublicStockDto.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/dto/PublicStockDto.java
@@ -1,0 +1,22 @@
+package rs.raf.stock_service.domain.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PublicStockDto {
+
+        private String security;
+        private String ticker;
+        private Integer amount;
+        private BigDecimal price;
+        private BigDecimal profit;
+        private LocalDateTime lastModified;
+        private String owner;
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/dto/SetPublicAmountDto.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/dto/SetPublicAmountDto.java
@@ -1,0 +1,15 @@
+package rs.raf.stock_service.domain.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Data
+@Builder
+@AllArgsConstructor
+public class SetPublicAmountDto {
+
+    private Long listingId;
+    private Integer publicAmount;
+
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/exceptions/InvalidListingTypeException.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/exceptions/InvalidListingTypeException.java
@@ -1,0 +1,8 @@
+package rs.raf.stock_service.exceptions;
+
+public class InvalidListingTypeException extends RuntimeException{
+
+    public InvalidListingTypeException(String message){
+        super(message);
+    }
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/exceptions/InvalidPublicAmountException.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/exceptions/InvalidPublicAmountException.java
@@ -1,0 +1,8 @@
+package rs.raf.stock_service.exceptions;
+
+public class InvalidPublicAmountException extends RuntimeException{
+
+    public InvalidPublicAmountException(String message){
+        super(message);
+    }
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/exceptions/PortfolioEntryNotFoundException.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/exceptions/PortfolioEntryNotFoundException.java
@@ -1,0 +1,7 @@
+package rs.raf.stock_service.exceptions;
+
+public class PortfolioEntryNotFoundException extends RuntimeException{
+    public PortfolioEntryNotFoundException(String message){
+        super(message);
+    }
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/repository/OptionRepository.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/repository/OptionRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import rs.raf.stock_service.domain.entity.Listing;
 import rs.raf.stock_service.domain.entity.Option;
+import rs.raf.stock_service.domain.entity.Stock;
 import rs.raf.stock_service.domain.enums.OptionType;
 
 import java.time.LocalDate;
@@ -16,8 +17,11 @@ import java.util.Optional;
 public interface OptionRepository extends JpaRepository<Option, Long> {
     List<Option> findByUnderlyingStockIdAndSettlementDate(Long stockId, LocalDate settlementDate);
 
-    List<Option> findAllByStock(Listing stock);
-  
+  //  List<Option> findAllByStock(Listing stock);
+
+    List<Option>findAllByUnderlyingStock(Stock stock);
+
+
     @Query("SELECT o FROM Option o")
     List<Option> findAllOptions();
 

--- a/stock-service/src/main/java/rs/raf/stock_service/repository/PortfolioEntryRepository.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/repository/PortfolioEntryRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import rs.raf.stock_service.domain.entity.PortfolioEntry;
 import rs.raf.stock_service.domain.entity.Listing;
+import rs.raf.stock_service.domain.enums.ListingType;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +17,8 @@ public interface PortfolioEntryRepository extends JpaRepository<PortfolioEntry, 
     Optional<PortfolioEntry> findByUserIdAndListing(Long userId, Listing listing);
 
     void deleteByUserIdAndListing(Long userId, Listing listing);
+
+    Optional<PortfolioEntry> findByUserIdAndListingId(Long userId, Long listingId);
+
+    List<PortfolioEntry> findAllByTypeAndPublicAmountGreaterThan(ListingType type, Integer minAmount);
 }

--- a/stock-service/src/main/java/rs/raf/stock_service/service/ListingService.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/service/ListingService.java
@@ -62,7 +62,7 @@ public class ListingService {
         ListingDetailsDto dto = listingMapper.toDetailsDto(listing, priceHistory);
 
         if (listing instanceof Stock) {
-            List<LocalDate> optionDates = optionRepository.findAllByStock(listing).stream()
+            List<LocalDate> optionDates = optionRepository.findAllByUnderlyingStock((Stock) listing).stream()
                     .map(Option::getSettlementDate)
                     .distinct()
                     .sorted()

--- a/stock-service/src/main/java/rs/raf/stock_service/service/PortfolioService.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/service/PortfolioService.java
@@ -1,11 +1,18 @@
 package rs.raf.stock_service.service;
 
 import lombok.AllArgsConstructor;
+import org.apache.coyote.BadRequestException;
+import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.stereotype.Service;
 import rs.raf.stock_service.domain.dto.PortfolioEntryDto;
+import rs.raf.stock_service.domain.dto.PublicStockDto;
+import rs.raf.stock_service.domain.dto.SetPublicAmountDto;
 import rs.raf.stock_service.domain.entity.*;
 import rs.raf.stock_service.domain.enums.ListingType;
 import rs.raf.stock_service.domain.enums.OrderDirection;
+import rs.raf.stock_service.exceptions.InvalidListingTypeException;
+import rs.raf.stock_service.exceptions.InvalidPublicAmountException;
+import rs.raf.stock_service.exceptions.PortfolioEntryNotFoundException;
 import rs.raf.stock_service.repository.*;
 import rs.raf.stock_service.domain.mapper.PortfolioMapper;
 
@@ -86,5 +93,55 @@ public class PortfolioService {
                             entry.getListing().getTicker(),
                             profit);
                 }).collect(Collectors.toList());
+    }
+
+    public void setPublicAmount(Long userId, SetPublicAmountDto dto) {
+        PortfolioEntry entry = portfolioEntryRepository.findByUserIdAndListingId(userId, dto.getListingId())
+                .orElseThrow(() -> new PortfolioEntryNotFoundException("Portfolio entry not found"));
+
+        // samo stock moze
+        if (entry.getType() != ListingType.STOCK) {
+            throw new InvalidListingTypeException("Only STOCK type can be made public.");
+        }
+
+
+        if (dto.getPublicAmount() > entry.getAmount()) {
+            throw new InvalidPublicAmountException("Public amount cannot exceed owned amount.");
+        }
+
+        entry.setPublicAmount(dto.getPublicAmount());
+        entry.setLastModified(LocalDateTime.now());
+
+        portfolioEntryRepository.save(entry);
+    }
+
+
+    public List<PublicStockDto> getAllPublicStocks() {
+        List<PortfolioEntry> publicEntries = portfolioEntryRepository.findAllByTypeAndPublicAmountGreaterThan(ListingType.STOCK, 0);
+
+        return publicEntries.stream().map(entry -> {
+            Listing listing = entry.getListing();
+
+
+            ListingDailyPriceInfo latestPriceInfo = dailyPriceInfoRepository
+                    .findTopByListingOrderByDateDesc(listing);
+
+            BigDecimal currentPrice = latestPriceInfo != null ? latestPriceInfo.getPrice() : BigDecimal.ZERO;
+            BigDecimal avgPrice = entry.getAveragePrice() != null ? entry.getAveragePrice() : BigDecimal.ZERO;
+
+            BigDecimal profit = currentPrice.subtract(avgPrice)
+                    .multiply(BigDecimal.valueOf(entry.getPublicAmount()));
+
+            return PublicStockDto.builder()
+                    .security(ListingType.STOCK.name())
+                    .ticker(listing.getTicker())
+                    .amount(entry.getPublicAmount())
+                    .price(currentPrice)
+                    .profit(profit)
+                    .lastModified(entry.getLastModified())
+                    .owner("user-" + entry.getUserId())               // privremeni owner
+                    .build();
+
+        }).collect(Collectors.toList());
     }
 }

--- a/stock-service/src/test/java/rs/raf/stock_service/unit/ListingServiceTest.java
+++ b/stock-service/src/test/java/rs/raf/stock_service/unit/ListingServiceTest.java
@@ -137,7 +137,7 @@ class ListingServiceTest {
         when(listingRepository.findById(1L)).thenReturn(Optional.of(stock));
         when(dailyPriceInfoRepository.findAllByListingOrderByDateDesc(stock)).thenReturn(priceHistory);
         when(listingMapper.toDetailsDto(stock, priceHistory)).thenReturn(expectedDto);
-        when(optionRepository.findAllByStock(stock)).thenReturn(List.of());
+        when(optionRepository.findAllByUnderlyingStock(stock)).thenReturn(List.of());
 
         // Poziv metode
         ListingDetailsDto result = listingService.getListingDetails(1L);


### PR DESCRIPTION
…istanje public akcija, mini promena u OptionRepository

## Opis
U ovom PR-u su implementirana dva nova endpointa za OTC portal u okviru portfolio servisa:

PUT /api/portfolio/public-amount – omogućava korisnicima da podele (postave) broj javno dostupnih akcija koje poseduju u svom portfoliju (samo za STOCK tip).

GET /api/portfolio/public-stocks – vraća listu svih javno dostupnih akcija (od svih korisnika) za prikaz u OTC portalu.

Oba endpointa uključuju validacije (tip listinga, granice količine, vlasništvo itd), potpunu servisnu logiku, exception handlovanje i dodao sam i unit testove za njih koji prolaze.



## Lista taskova pri pravljenju PR-a
- [ ] Dodao sam testove koji dokazuju da moj fix ili funkcionalnost rade kako se očekuje.

![image](https://github.com/user-attachments/assets/605a7240-c418-4df9-a169-e2dac1d9f361)

- [ ] Dokumentovao/la sam svoje promene u dokumentu sa endpointima.
- [ ] Priložio/la sam Postman screenshot-ove za svaki slučaj za svaki endpoint.
- [ ] Ako je primenjivo, objasnio sam user flow vezan za ove promene.

## Screenshot-ovi (ako je primenjivo)
Molimo priložite screenshot-ove iz Postmana za svaki endpoint i slučaj, uključujući uspešne i neuspešne scenarije.
![image](https://github.com/user-attachments/assets/ce01c931-baa6-4114-b02d-60fbad0d913d)
![image](https://github.com/user-attachments/assets/4ee49d2a-4a15-4dee-96a9-8c14f21a93a6)
ovde se vidi da se uspesno setovalo
![image](https://github.com/user-attachments/assets/5c6e679c-6e3d-4e4f-8cbf-a845da1b32d8)
get za public-stocks
![image](https://github.com/user-attachments/assets/2d1b3458-0ce8-44b5-af37-776c59ad1b1c)

Negativni slucajevi 
![image](https://github.com/user-attachments/assets/7083dc85-bbc4-403e-8340-a487615d4262)
![image](https://github.com/user-attachments/assets/073b0af8-6e00-4214-b1be-07a4708c04ce)



## Objašnjenje korisničkog toka (ako je primenjivo)

Klijent može da vidi svoj portfolio putem GET /api/portfolio

Ako želi da ponudi akcije drugima putem OTC portala, koristi PUT /api/portfolio/public-amount da postavi javnu kolicinu

Sve javno ponudjeeene akcije dostupne su svim korisnicima putem GET /api/portfolio/public-stocks, gde se mogu prikazati i dalje koristiti za davanje ponuda

## Dodatne napomene
Owner prikaz u OTC listi je trenutno privremeni tekst "user-{id}"
