### PR TITLE
Dodata polja premium i option u OtcOffer entitet 

### DIFF
--- a/stock-service/src/main/java/rs/raf/stock_service/domain/entity/Option.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/entity/Option.java
@@ -1,9 +1,6 @@
 package rs.raf.stock_service.domain.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import rs.raf.stock_service.domain.enums.OptionType;
 
 import javax.persistence.*;
@@ -16,6 +13,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @NoArgsConstructor
 @DiscriminatorValue("OPTION")
+@Builder
 public class Option extends Listing {
     @Enumerated(EnumType.STRING)
     private OptionType optionType;
@@ -31,4 +29,7 @@ public class Option extends Listing {
     @JoinColumn(name = "stock_id")
     private Stock underlyingStock;
 
+    @ManyToOne
+    @JoinColumn(name = "otc_offer_id", nullable = true)
+    private OtcOffer offer;
 }

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/entity/Option.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/entity/Option.java
@@ -29,7 +29,7 @@ public class Option extends Listing {
     @JoinColumn(name = "stock_id")
     private Stock underlyingStock;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "otc_offer_id", nullable = true)
     private OtcOffer offer;
 }

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/entity/OtcOffer.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/entity/OtcOffer.java
@@ -1,0 +1,44 @@
+package rs.raf.stock_service.domain.entity;
+
+
+import lombok.*;
+import rs.raf.stock_service.domain.enums.OtcOfferStatus;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OtcOffer {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "stock_id")
+    private Stock stock;
+
+    private Long buyerId;
+    private Long sellerId;
+
+    private Integer amount;
+    private BigDecimal pricePerStock;
+    private BigDecimal premium;
+    private LocalDate settlementDate;
+
+    private LocalDateTime lastModified;
+    private Long lastModifiedById;
+
+    @Enumerated(EnumType.STRING)
+    private OtcOfferStatus status;
+
+    @OneToOne
+    private Option option;
+
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/enums/OtcOfferStatus.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/enums/OtcOfferStatus.java
@@ -1,0 +1,7 @@
+package rs.raf.stock_service.domain.enums;
+
+public enum OtcOfferStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED
+}


### PR DESCRIPTION


Ažuriran OtcOffer entitet prema ažuriranoj specifikaciji iz Celine 4 — dodat je premium (cena koju kupac placa), zamenjen Listing sa Stock jer se ponude odnose isključivo na akcije, i dodat Option kao referenca na kreiranu opciju nakon prihvatanja ponude. 

OtcContract entitet je uklonjen jer je suvisan – sve podatke već sadrže OtcOffer i Option.