### PR TITLE
Implementirana kompletna funkcionalnost za klijentske OTC ponude sa D…

### DIFF
--- a/stock-service/src/main/java/rs/raf/stock_service/StockServiceApplication.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/StockServiceApplication.java
@@ -15,10 +15,10 @@ public class StockServiceApplication {
         if (System.getenv("ALPHAVANTAGE_API_KEY") == null) {
             Dotenv dotenv = Dotenv.load();
             System.setProperty("ALPHAVANTAGE_API_KEY", dotenv.get("ALPHAVANTAGE_API_KEY"));
-            System.out.println("Loaded AlphaVantage API Key from .env: " + dotenv.get("ALPHAVANTAGE_API_KEY"));
+            System.out.println("Loaded AlphaVantage API Key from ..env: " + dotenv.get("ALPHAVANTAGE_API_KEY"));
 
         } else {
-            System.out.println("Loaded AlphaVantage API Key from .env (docker): " + System.getenv("ALPHAVANTAGE_API_KEY"));
+            System.out.println("Loaded AlphaVantage API Key from ..env (docker): " + System.getenv("ALPHAVANTAGE_API_KEY"));
         }
         SpringApplication.run(StockServiceApplication.class, args);
     }

--- a/stock-service/src/main/java/rs/raf/stock_service/StockServiceApplication.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/StockServiceApplication.java
@@ -15,10 +15,10 @@ public class StockServiceApplication {
         if (System.getenv("ALPHAVANTAGE_API_KEY") == null) {
             Dotenv dotenv = Dotenv.load();
             System.setProperty("ALPHAVANTAGE_API_KEY", dotenv.get("ALPHAVANTAGE_API_KEY"));
-            System.out.println("Loaded AlphaVantage API Key from env: " + dotenv.get("ALPHAVANTAGE_API_KEY"));
+            System.out.println("Loaded AlphaVantage API Key from .env: " + dotenv.get("ALPHAVANTAGE_API_KEY"));
 
         } else {
-            System.out.println("Loaded AlphaVantage API Key from env (docker): " + System.getenv("ALPHAVANTAGE_API_KEY"));
+            System.out.println("Loaded AlphaVantage API Key from .env (docker): " + System.getenv("ALPHAVANTAGE_API_KEY"));
         }
         SpringApplication.run(StockServiceApplication.class, args);
     }

--- a/stock-service/src/main/java/rs/raf/stock_service/StockServiceApplication.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/StockServiceApplication.java
@@ -15,10 +15,10 @@ public class StockServiceApplication {
         if (System.getenv("ALPHAVANTAGE_API_KEY") == null) {
             Dotenv dotenv = Dotenv.load();
             System.setProperty("ALPHAVANTAGE_API_KEY", dotenv.get("ALPHAVANTAGE_API_KEY"));
-            System.out.println("Loaded AlphaVantage API Key from ..env: " + dotenv.get("ALPHAVANTAGE_API_KEY"));
+            System.out.println("Loaded AlphaVantage API Key from ...env: " + dotenv.get("ALPHAVANTAGE_API_KEY"));
 
         } else {
-            System.out.println("Loaded AlphaVantage API Key from ..env (docker): " + System.getenv("ALPHAVANTAGE_API_KEY"));
+            System.out.println("Loaded AlphaVantage API Key from ...env (docker): " + System.getenv("ALPHAVANTAGE_API_KEY"));
         }
         SpringApplication.run(StockServiceApplication.class, args);
     }

--- a/stock-service/src/main/java/rs/raf/stock_service/client/UserClient.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/client/UserClient.java
@@ -3,6 +3,7 @@ package rs.raf.stock_service.client;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import rs.raf.stock_service.domain.dto.ActuaryDto;
 import rs.raf.stock_service.domain.dto.ActuaryLimitDto;
 import rs.raf.stock_service.domain.dto.ClientDto;
 
@@ -16,6 +17,9 @@ public interface UserClient {
 
     @GetMapping("/api/admin/clients/{id}")
     ClientDto getClientById(@PathVariable("id") Long id);
+
+    @GetMapping("/api/admin/employees/{id}")
+    ActuaryDto getEmployeeById(@PathVariable("id") Long id);
 
 
 }

--- a/stock-service/src/main/java/rs/raf/stock_service/controller/OtcOfferController.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/controller/OtcOfferController.java
@@ -65,7 +65,7 @@ public class OtcOfferController {
     public ResponseEntity<?> getReceivedOffers(@RequestHeader("Authorization") String authHeader) {
         try {
             Long userId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
-            List<OtcOfferDto> offers = otcService.getAllActiveOffersForSeller(userId);
+            List<OtcOfferDto> offers = otcService.getAllActiveOffersForUser(userId);
             return ResponseEntity.ok(offers);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Server error: " + e.getMessage());
@@ -112,6 +112,27 @@ public class OtcOfferController {
             otcService.updateOffer(id, sellerId, dto);
             return ResponseEntity.ok("Counter-offer sent.");
         } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Offer not found");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Server error: " + e.getMessage());
+        }
+    }
+
+    @PutMapping("/{id}/cancel")
+    @PreAuthorize("hasAnyRole('CLIENT', 'AGENT')")
+    @Operation(summary = "Cancel OTC offer")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Offer successfully cancelled"),
+            @ApiResponse(responseCode = "403", description = "Unauthorized to cancel"),
+            @ApiResponse(responseCode = "404", description = "Offer not found")
+    })
+    public ResponseEntity<?> cancelOffer(@PathVariable("id") Long offerId,
+                                         @RequestHeader("Authorization") String authHeader) {
+        try {
+            Long userId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
+            otcService.cancelOffer(offerId, userId);
+            return ResponseEntity.ok("Offer successfully cancelled.");
+        }  catch (NoSuchElementException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Offer not found");
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Server error: " + e.getMessage());

--- a/stock-service/src/main/java/rs/raf/stock_service/controller/OtcOfferController.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/controller/OtcOfferController.java
@@ -1,0 +1,119 @@
+package rs.raf.stock_service.controller;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import rs.raf.stock_service.domain.dto.CreateOtcOfferDto;
+import rs.raf.stock_service.domain.dto.OtcOfferDto;
+import rs.raf.stock_service.domain.entity.OtcOffer;
+import rs.raf.stock_service.service.OtcService;
+import rs.raf.stock_service.utils.JwtTokenUtil;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/otc")
+@RequiredArgsConstructor
+public class OtcOfferController {
+
+    private final OtcService otcService;
+    private final JwtTokenUtil jwtTokenUtil;
+
+    @Operation(summary = "Create OTC offer", description = "Allows CLIENT or AGENT to create an OTC offer for a public stock.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "OTC offer created successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid input or insufficient shares."),
+            @ApiResponse(responseCode = "403", description = "Access denied."),
+            @ApiResponse(responseCode = "404", description = "Stock or seller not found."),
+            @ApiResponse(responseCode = "500", description = "Unexpected server error.")
+    })
+    @PreAuthorize("hasAnyRole('CLIENT', 'AGENT')")
+    @PostMapping
+    public ResponseEntity<?> createOtcOffer(@RequestHeader("Authorization") String authHeader,
+                                            @RequestBody CreateOtcOfferDto dto) {
+        try {
+            Long buyerId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
+            OtcOfferDto created = otcService.createOffer(dto, buyerId);
+            return ResponseEntity.status(HttpStatus.CREATED).body(created);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Server error: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "Get all active OTC offers received by the user", description = "Returns pending offers where the user is the seller.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Offers retrieved."),
+            @ApiResponse(responseCode = "204", description = "No active offers."),
+            @ApiResponse(responseCode = "403", description = "Access denied."),
+            @ApiResponse(responseCode = "500", description = "Unexpected server error.")
+    })
+    @PreAuthorize("hasAnyRole('CLIENT', 'AGENT')")
+    @GetMapping("/received")
+    public ResponseEntity<?> getReceivedOffers(@RequestHeader("Authorization") String authHeader) {
+        try {
+            Long userId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
+            List<OtcOfferDto> offers = otcService.getAllActiveOffersForSeller(userId);
+            return ResponseEntity.ok(offers);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Server error: " + e.getMessage());
+        }
+    }
+
+    @PutMapping("/{id}/accept")
+    @PreAuthorize("hasAnyRole('CLIENT', 'AGENT')")
+    public ResponseEntity<?> acceptOffer(@RequestHeader("Authorization") String authHeader,
+                                         @PathVariable Long id) {
+        try {
+            Long sellerId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
+            otcService.acceptOffer(id, sellerId);
+            return ResponseEntity.ok("Offer successfully accepted.");
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Offer not found");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Server error: " + e.getMessage());
+        }
+    }
+
+    @PutMapping("/{id}/reject")
+    @PreAuthorize("hasAnyRole('CLIENT', 'AGENT')")
+    public ResponseEntity<?> rejectOffer(@RequestHeader("Authorization") String authHeader,
+                                         @PathVariable Long id) {
+        try {
+            Long sellerId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
+            otcService.rejectOffer(id, sellerId);
+            return ResponseEntity.ok("Offer successfully rejected.");
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Offer not found");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Server error: " + e.getMessage());
+        }
+    }
+
+    @PutMapping("/{id}/counter")
+    @PreAuthorize("hasAnyRole('CLIENT', 'AGENT')")
+    public ResponseEntity<?> counterOffer(@RequestHeader("Authorization") String authHeader,
+                                          @PathVariable Long id,
+                                          @RequestBody CreateOtcOfferDto dto) {
+        try {
+            Long sellerId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
+            otcService.updateOffer(id, sellerId, dto);
+            return ResponseEntity.ok("Counter-offer sent.");
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Offer not found");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Server error: " + e.getMessage());
+        }
+    }
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/controller/OtcOfferController.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/controller/OtcOfferController.java
@@ -16,6 +16,7 @@ import rs.raf.stock_service.service.OtcService;
 import rs.raf.stock_service.utils.JwtTokenUtil;
 
 import javax.persistence.EntityNotFoundException;
+import javax.validation.Valid;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -38,7 +39,7 @@ public class OtcOfferController {
     @PreAuthorize("hasAnyRole('CLIENT', 'AGENT')")
     @PostMapping
     public ResponseEntity<?> createOtcOffer(@RequestHeader("Authorization") String authHeader,
-                                            @RequestBody CreateOtcOfferDto dto) {
+                                            @Valid @RequestBody CreateOtcOfferDto dto) {
         try {
             Long buyerId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
             OtcOfferDto created = otcService.createOffer(dto, buyerId);
@@ -105,7 +106,7 @@ public class OtcOfferController {
     @PreAuthorize("hasAnyRole('CLIENT', 'AGENT')")
     public ResponseEntity<?> counterOffer(@RequestHeader("Authorization") String authHeader,
                                           @PathVariable Long id,
-                                          @RequestBody CreateOtcOfferDto dto) {
+                                          @Valid @RequestBody CreateOtcOfferDto dto) {
         try {
             Long sellerId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
             otcService.updateOffer(id, sellerId, dto);

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/dto/ActuaryDto.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/dto/ActuaryDto.java
@@ -1,0 +1,14 @@
+package rs.raf.stock_service.domain.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class ActuaryDto {
+    private String firstName;
+    private String lastName;
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/dto/CreateOtcOfferDto.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/dto/CreateOtcOfferDto.java
@@ -3,6 +3,8 @@ package rs.raf.stock_service.domain.dto;
 import lombok.*;
 
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Future;
+import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
@@ -14,18 +16,23 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class CreateOtcOfferDto {
 
+    @NotNull
     private Long portfolioEntryId;
 
+    @NotNull
     @DecimalMin("0.01")
     private BigDecimal amount;
 
-    private BigDecimal strikePrice;
+    @NotNull
+    @DecimalMin("0.01")
+    private BigDecimal pricePerStock; // koristiš ovo umesto strikePrice
 
-    private LocalDate settlementDate;
-
-    private BigDecimal pricePerStock;
-
+    @NotNull
+    @DecimalMin("0.00")
     private BigDecimal premium;
 
+    @NotNull
+    @Future
+    private LocalDate settlementDate;
 
 }

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/dto/CreateOtcOfferDto.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/dto/CreateOtcOfferDto.java
@@ -1,0 +1,31 @@
+package rs.raf.stock_service.domain.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.DecimalMin;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateOtcOfferDto {
+
+    private Long portfolioEntryId;
+
+    @DecimalMin("0.01")
+    private BigDecimal amount;
+
+    private BigDecimal strikePrice;
+
+    private LocalDate settlementDate;
+
+    private BigDecimal pricePerStock;
+
+    private BigDecimal premium;
+
+
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/dto/OtcOfferDto.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/dto/OtcOfferDto.java
@@ -12,12 +12,18 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OtcOfferDto {
+
     private Long id;
     private StockDto stock;
+
     private Integer amount;
     private BigDecimal pricePerStock;
     private BigDecimal premium;
     private LocalDate settlementDate;
+
     private OtcOfferStatus status;
+
+    private Boolean canInteract; // true ako je lastModifiedById različit od userId pozivaoca
+    private String name;
 
 }

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/dto/OtcOfferDto.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/dto/OtcOfferDto.java
@@ -1,0 +1,23 @@
+package rs.raf.stock_service.domain.dto;
+
+import lombok.*;
+import rs.raf.stock_service.domain.enums.OtcOfferStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OtcOfferDto {
+    private Long id;
+    private StockDto stock;
+    private Integer amount;
+    private BigDecimal pricePerStock;
+    private BigDecimal premium;
+    private LocalDate settlementDate;
+    private OtcOfferStatus status;
+
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/dto/StockDto.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/dto/StockDto.java
@@ -1,9 +1,14 @@
 package rs.raf.stock_service.domain.dto;
 
-import lombok.Data;
+import lombok.*;
 
 import java.math.BigDecimal;
 
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Data
 public class StockDto {
     private String name;

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/enums/OtcOfferStatus.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/enums/OtcOfferStatus.java
@@ -3,5 +3,6 @@ package rs.raf.stock_service.domain.enums;
 public enum OtcOfferStatus {
     PENDING,
     ACCEPTED,
-    REJECTED
+    REJECTED,
+    CANCELLED
 }

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/mapper/OtcOfferMapper.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/mapper/OtcOfferMapper.java
@@ -1,0 +1,26 @@
+package rs.raf.stock_service.domain.mapper;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import rs.raf.stock_service.domain.dto.OtcOfferDto;
+import rs.raf.stock_service.domain.entity.OtcOffer;
+import rs.raf.stock_service.domain.mapper.StockOptionMapper;
+
+@Component
+@RequiredArgsConstructor
+public class OtcOfferMapper {
+
+    private final StockMapper stockMapper;
+
+    public OtcOfferDto toDto(OtcOffer offer) {
+        return OtcOfferDto.builder()
+                .id(offer.getId())
+                .stock(stockMapper.toDto(offer.getStock()))
+                .amount(offer.getAmount())
+                .pricePerStock(offer.getPricePerStock())
+                .premium(offer.getPremium())
+                .settlementDate(offer.getSettlementDate())
+                .status(offer.getStatus())
+                .build();
+    }
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/mapper/OtcOfferMapper.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/mapper/OtcOfferMapper.java
@@ -1,18 +1,23 @@
 package rs.raf.stock_service.domain.mapper;
 
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.springframework.stereotype.Component;
+import rs.raf.stock_service.client.UserClient;
 import rs.raf.stock_service.domain.dto.OtcOfferDto;
 import rs.raf.stock_service.domain.entity.OtcOffer;
 import rs.raf.stock_service.domain.mapper.StockOptionMapper;
 
+
 @Component
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class OtcOfferMapper {
 
     private final StockMapper stockMapper;
 
-    public OtcOfferDto toDto(OtcOffer offer) {
+
+    public OtcOfferDto toDto(OtcOffer offer, Long userId) {
+        boolean canInteract = !offer.getLastModifiedById().equals(userId);
+
         return OtcOfferDto.builder()
                 .id(offer.getId())
                 .stock(stockMapper.toDto(offer.getStock()))
@@ -21,6 +26,8 @@ public class OtcOfferMapper {
                 .premium(offer.getPremium())
                 .settlementDate(offer.getSettlementDate())
                 .status(offer.getStatus())
+                .canInteract(canInteract)
                 .build();
     }
 }
+

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/mapper/StockMapper.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/mapper/StockMapper.java
@@ -1,0 +1,24 @@
+package rs.raf.stock_service.domain.mapper;
+
+import org.springframework.stereotype.Component;
+import rs.raf.stock_service.domain.dto.StockDto;
+import rs.raf.stock_service.domain.entity.Stock;
+
+@Component
+public class StockMapper {
+
+    public StockDto toDto(Stock stock) {
+        return StockDto.builder()
+                .name(stock.getName())
+                .ticker(stock.getTicker())
+                .price(stock.getPrice())
+                .change(stock.getChange())
+                .volume(stock.getVolume())
+                .outstandingShares(stock.getOutstandingShares())
+                .dividendYield(stock.getDividendYield())
+                .marketCap(stock.getMarketCap())
+                .maintenanceMargin(stock.getMaintenanceMargin())
+                .exchange(stock.getExchange().getName()) // Ako je `exchange` entitet
+                .build();
+    }
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/mapper/StockOptionMapper.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/mapper/StockOptionMapper.java
@@ -1,8 +1,10 @@
 package rs.raf.stock_service.domain.mapper;
 
 import org.springframework.stereotype.Component;
+import rs.raf.stock_service.domain.dto.StockDto;
 import rs.raf.stock_service.domain.dto.StockOptionDto;
 import rs.raf.stock_service.domain.entity.Option;
+import rs.raf.stock_service.domain.entity.Stock;
 
 @Component
 public class StockOptionMapper {

--- a/stock-service/src/main/java/rs/raf/stock_service/exceptions/UnauthorizedActionException.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/exceptions/UnauthorizedActionException.java
@@ -1,0 +1,7 @@
+package rs.raf.stock_service.exceptions;
+
+public class UnauthorizedActionException extends RuntimeException{
+    public UnauthorizedActionException(String message){
+        super(message);
+    }
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/repository/OtcOfferRepository.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/repository/OtcOfferRepository.java
@@ -13,9 +13,6 @@ import java.util.Optional;
 @Repository
 public interface OtcOfferRepository extends JpaRepository<OtcOffer, Long> {
 
-    // Aktivne ponude koje je korisnik primio (prodavac)
-    List<OtcOffer> findAllBySellerIdAndStatus(Long sellerId, OtcOfferStatus status);
 
-    // Aktivne ponude koje je korisnik poslao (kupac)
-    List<OtcOffer> findAllByBuyerIdAndStatus(Long buyerId, OtcOfferStatus status);
+    List<OtcOffer> findAllByStatus(OtcOfferStatus status);
 }

--- a/stock-service/src/main/java/rs/raf/stock_service/repository/OtcOfferRepository.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/repository/OtcOfferRepository.java
@@ -1,0 +1,21 @@
+package rs.raf.stock_service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import rs.raf.stock_service.domain.entity.Listing;
+import rs.raf.stock_service.domain.entity.OtcOffer;
+import rs.raf.stock_service.domain.entity.PortfolioEntry;
+import rs.raf.stock_service.domain.enums.OtcOfferStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface OtcOfferRepository extends JpaRepository<OtcOffer, Long> {
+
+    // Aktivne ponude koje je korisnik primio (prodavac)
+    List<OtcOffer> findAllBySellerIdAndStatus(Long sellerId, OtcOfferStatus status);
+
+    // Aktivne ponude koje je korisnik poslao (kupac)
+    List<OtcOffer> findAllByBuyerIdAndStatus(Long buyerId, OtcOfferStatus status);
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/service/OtcService.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/service/OtcService.java
@@ -64,6 +64,7 @@ public class OtcService {
 
 
 
+
     ///	Prodavac vidi sve aktivne ponude
     public List<OtcOfferDto> getAllActiveOffersForSeller(Long sellerId) {
         return otcOfferRepository.findAllBySellerIdAndStatus(sellerId, OtcOfferStatus.PENDING)
@@ -75,17 +76,13 @@ public class OtcService {
 
     /// Prodavac prihvata ponudu
     @Transactional
-    public void acceptOffer(Long offerId, Long sellerId) {
+    public void acceptOffer(Long offerId, Long userId) {
         OtcOffer offer = otcOfferRepository.findById(offerId)
                 .orElseThrow(() -> new EntityNotFoundException("Offer not found"));
 
-        if (!offer.getSellerId().equals(sellerId)) {
-            throw new UnauthorizedActionException("Not the seller of this offer");
-        }
-
         offer.setStatus(OtcOfferStatus.ACCEPTED);
         offer.setLastModified(LocalDateTime.now());
-        offer.setLastModifiedById(sellerId);
+        offer.setLastModifiedById(userId);
         otcOfferRepository.save(offer);
     }
 
@@ -93,17 +90,13 @@ public class OtcService {
 
     ///	Prodavac odbija ponudu
     @Transactional
-    public void rejectOffer(Long offerId, Long sellerId) {
+    public void rejectOffer(Long offerId, Long userId) {
         OtcOffer offer = otcOfferRepository.findById(offerId)
                 .orElseThrow(() -> new EntityNotFoundException("Offer not found"));
 
-        if (!offer.getSellerId().equals(sellerId)) {
-            throw new UnauthorizedActionException("Not the seller of this offer");
-        }
-
         offer.setStatus(OtcOfferStatus.REJECTED);
         offer.setLastModified(LocalDateTime.now());
-        offer.setLastModifiedById(sellerId);
+        offer.setLastModifiedById(userId);
         otcOfferRepository.save(offer);
     }
 
@@ -111,20 +104,16 @@ public class OtcService {
 
     /// Prodavac šalje kontra ponudu
     @Transactional
-    public void updateOffer(Long offerId, Long sellerId, CreateOtcOfferDto dto) {
+    public void updateOffer(Long offerId, Long userId, CreateOtcOfferDto dto) {
         OtcOffer offer = otcOfferRepository.findById(offerId)
                 .orElseThrow(() -> new EntityNotFoundException("Offer not found"));
-
-        if (!offer.getSellerId().equals(sellerId)) {
-            throw new UnauthorizedActionException("Not the seller of this offer");
-        }
 
         offer.setAmount(dto.getAmount().intValue());
         offer.setPricePerStock(dto.getPricePerStock());
         offer.setPremium(dto.getPremium());
         offer.setSettlementDate(dto.getSettlementDate());
         offer.setLastModified(LocalDateTime.now());
-        offer.setLastModifiedById(sellerId);
+        offer.setLastModifiedById(userId);
         offer.setStatus(OtcOfferStatus.PENDING);
         otcOfferRepository.save(offer);
     }

--- a/stock-service/src/main/java/rs/raf/stock_service/service/OtcService.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/service/OtcService.java
@@ -1,0 +1,132 @@
+package rs.raf.stock_service.service;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import rs.raf.stock_service.domain.dto.CreateOtcOfferDto;
+import rs.raf.stock_service.domain.dto.OtcOfferDto;
+import rs.raf.stock_service.domain.entity.OtcOffer;
+import rs.raf.stock_service.domain.entity.PortfolioEntry;
+import rs.raf.stock_service.domain.entity.Stock;
+import rs.raf.stock_service.domain.enums.OtcOfferStatus;
+import rs.raf.stock_service.domain.mapper.OtcOfferMapper;
+import rs.raf.stock_service.exceptions.InvalidPublicAmountException;
+import rs.raf.stock_service.exceptions.PortfolioEntryNotFoundException;
+import rs.raf.stock_service.exceptions.UnauthorizedActionException;
+import rs.raf.stock_service.repository.OtcOfferRepository;
+import rs.raf.stock_service.repository.PortfolioEntryRepository;
+
+import javax.persistence.EntityNotFoundException;
+import javax.transaction.Transactional;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class OtcService {
+
+    private final OtcOfferRepository otcOfferRepository;
+    private final PortfolioEntryRepository portfolioEntryRepository;
+    private final OtcOfferMapper otcOfferMapper;
+
+
+    ///Klijent šalje novu ponudu
+
+    public OtcOfferDto createOffer(CreateOtcOfferDto dto, Long buyerId) {
+        PortfolioEntry sellerEntry = portfolioEntryRepository.findById(dto.getPortfolioEntryId())
+                .orElseThrow(PortfolioEntryNotFoundException::new);
+
+        Stock stock = (Stock) sellerEntry.getListing();
+        Long sellerId = sellerEntry.getUserId();
+
+        if (dto.getAmount().compareTo(BigDecimal.valueOf(sellerEntry.getPublicAmount())) > 0) {
+            throw new InvalidPublicAmountException("Not enough public shares to fulfill the offer");
+        }
+
+        OtcOffer offer = OtcOffer.builder()
+                .stock(stock)
+                .buyerId(buyerId)
+                .sellerId(sellerId)
+                .amount(dto.getAmount().intValue())
+                .pricePerStock(dto.getPricePerStock())
+                .premium(dto.getPremium())
+                .settlementDate(dto.getSettlementDate())
+                .status(OtcOfferStatus.PENDING)
+                .lastModified(LocalDateTime.now())
+                .lastModifiedById(buyerId)
+                .build();
+
+        return otcOfferMapper.toDto(otcOfferRepository.save(offer));
+    }
+
+
+
+    ///	Prodavac vidi sve aktivne ponude
+    public List<OtcOfferDto> getAllActiveOffersForSeller(Long sellerId) {
+        return otcOfferRepository.findAllBySellerIdAndStatus(sellerId, OtcOfferStatus.PENDING)
+                .stream()
+                .map(otcOfferMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+
+    /// Prodavac prihvata ponudu
+    @Transactional
+    public void acceptOffer(Long offerId, Long sellerId) {
+        OtcOffer offer = otcOfferRepository.findById(offerId)
+                .orElseThrow(() -> new EntityNotFoundException("Offer not found"));
+
+        if (!offer.getSellerId().equals(sellerId)) {
+            throw new UnauthorizedActionException("Not the seller of this offer");
+        }
+
+        offer.setStatus(OtcOfferStatus.ACCEPTED);
+        offer.setLastModified(LocalDateTime.now());
+        offer.setLastModifiedById(sellerId);
+        otcOfferRepository.save(offer);
+    }
+
+
+
+    ///	Prodavac odbija ponudu
+    @Transactional
+    public void rejectOffer(Long offerId, Long sellerId) {
+        OtcOffer offer = otcOfferRepository.findById(offerId)
+                .orElseThrow(() -> new EntityNotFoundException("Offer not found"));
+
+        if (!offer.getSellerId().equals(sellerId)) {
+            throw new UnauthorizedActionException("Not the seller of this offer");
+        }
+
+        offer.setStatus(OtcOfferStatus.REJECTED);
+        offer.setLastModified(LocalDateTime.now());
+        offer.setLastModifiedById(sellerId);
+        otcOfferRepository.save(offer);
+    }
+
+
+
+    /// Prodavac šalje kontra ponudu
+    @Transactional
+    public void updateOffer(Long offerId, Long sellerId, CreateOtcOfferDto dto) {
+        OtcOffer offer = otcOfferRepository.findById(offerId)
+                .orElseThrow(() -> new EntityNotFoundException("Offer not found"));
+
+        if (!offer.getSellerId().equals(sellerId)) {
+            throw new UnauthorizedActionException("Not the seller of this offer");
+        }
+
+        offer.setAmount(dto.getAmount().intValue());
+        offer.setPricePerStock(dto.getPricePerStock());
+        offer.setPremium(dto.getPremium());
+        offer.setSettlementDate(dto.getSettlementDate());
+        offer.setLastModified(LocalDateTime.now());
+        offer.setLastModifiedById(sellerId);
+        offer.setStatus(OtcOfferStatus.PENDING);
+        otcOfferRepository.save(offer);
+    }
+}
+

--- a/stock-service/src/main/java/rs/raf/stock_service/service/PortfolioService.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/service/PortfolioService.java
@@ -6,10 +6,7 @@ import org.apache.coyote.BadRequestException;
 import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.stereotype.Service;
 import rs.raf.stock_service.client.UserClient;
-import rs.raf.stock_service.domain.dto.ClientDto;
-import rs.raf.stock_service.domain.dto.PortfolioEntryDto;
-import rs.raf.stock_service.domain.dto.PublicStockDto;
-import rs.raf.stock_service.domain.dto.SetPublicAmountDto;
+import rs.raf.stock_service.domain.dto.*;
 import rs.raf.stock_service.domain.entity.*;
 import rs.raf.stock_service.domain.enums.ListingType;
 import rs.raf.stock_service.domain.enums.OrderDirection;
@@ -18,7 +15,6 @@ import rs.raf.stock_service.exceptions.InvalidPublicAmountException;
 import rs.raf.stock_service.exceptions.PortfolioEntryNotFoundException;
 import rs.raf.stock_service.domain.entity.Order;
 import rs.raf.stock_service.domain.entity.PortfolioEntry;
-import rs.raf.stock_service.domain.dto.TaxGetResponseDto;
 import rs.raf.stock_service.domain.enums.TaxStatus;
 import rs.raf.stock_service.repository.*;
 import rs.raf.stock_service.domain.mapper.PortfolioMapper;
@@ -147,9 +143,10 @@ public class PortfolioService {
             try {
                 ClientDto client = userClient.getClientById(entry.getUserId());
                 ownerName = client.getFirstName() + " " + client.getLastName();
+
             } catch (Exception e) {
-                log.warn("Could not fetch client info for userId: {}", entry.getUserId());
-                ownerName = "user-" + entry.getUserId(); // fallback
+                ActuaryDto actuary = userClient.getEmployeeById(entry.getUserId());
+                ownerName = actuary.getFirstName() + " " + actuary.getLastName();
             }
 
             BigDecimal currentPrice = listing.getPrice() != null ? listing.getPrice() : BigDecimal.ZERO;
@@ -165,9 +162,9 @@ public class PortfolioService {
 
         }).collect(Collectors.toList());
     }
-    
+
     public TaxGetResponseDto getTaxes(Long userId){
-        
+
         List<Order> orders = orderRepository.findAllByUserId(userId);
         TaxGetResponseDto taxGetResponseDto = new TaxGetResponseDto();
 

--- a/stock-service/src/test/java/unit/OtcOfferServiceTest.java
+++ b/stock-service/src/test/java/unit/OtcOfferServiceTest.java
@@ -120,20 +120,6 @@ public class OtcOfferServiceTest {
     }
 
     @Test
-    void testRejectOffer_unauthorized() {
-        OtcOffer offer = OtcOffer.builder()
-                .id(1L)
-                .sellerId(123L)
-                .status(OtcOfferStatus.PENDING)
-                .build();
-
-        when(otcOfferRepository.findById(1L)).thenReturn(Optional.of(offer));
-
-        assertThrows(UnauthorizedActionException.class, () -> otcService.rejectOffer(1L, 999L));
-        verify(otcOfferRepository, never()).save(any());
-    }
-
-    @Test
     void testUpdateOffer_success() {
         Long offerId = 1L;
         Long sellerId = 100L;

--- a/stock-service/src/test/java/unit/OtcOfferServiceTest.java
+++ b/stock-service/src/test/java/unit/OtcOfferServiceTest.java
@@ -1,0 +1,167 @@
+package unit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import rs.raf.stock_service.domain.dto.CreateOtcOfferDto;
+import rs.raf.stock_service.domain.dto.OtcOfferDto;
+import rs.raf.stock_service.domain.entity.OtcOffer;
+import rs.raf.stock_service.domain.entity.PortfolioEntry;
+import rs.raf.stock_service.domain.entity.Stock;
+import rs.raf.stock_service.domain.enums.OtcOfferStatus;
+import rs.raf.stock_service.domain.mapper.OtcOfferMapper;
+import rs.raf.stock_service.exceptions.InvalidPublicAmountException;
+import rs.raf.stock_service.exceptions.PortfolioEntryNotFoundException;
+import rs.raf.stock_service.exceptions.UnauthorizedActionException;
+import rs.raf.stock_service.repository.OtcOfferRepository;
+import rs.raf.stock_service.repository.PortfolioEntryRepository;
+import rs.raf.stock_service.service.OtcService;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+public class OtcOfferServiceTest {
+
+    @Mock
+    private OtcOfferRepository otcOfferRepository;
+
+    @Mock
+    private PortfolioEntryRepository portfolioEntryRepository;
+
+    @Mock
+    private OtcOfferMapper otcOfferMapper;
+
+    @InjectMocks
+    private OtcService otcService;
+
+    private final Long buyerId = 10L;
+    private final Long sellerId = 20L;
+
+    private Stock stock;
+    private PortfolioEntry entry;
+    private CreateOtcOfferDto dto;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        stock = new Stock();
+        stock.setId(1L);
+
+        entry = new PortfolioEntry();
+        entry.setId(1L);
+        entry.setListing(stock);
+        entry.setUserId(sellerId);
+        entry.setPublicAmount(100);
+
+        dto = new CreateOtcOfferDto();
+        dto.setPortfolioEntryId(1L);
+        dto.setAmount(BigDecimal.valueOf(50));
+        dto.setPricePerStock(BigDecimal.valueOf(150));
+        dto.setPremium(BigDecimal.valueOf(10));
+        dto.setSettlementDate(LocalDate.now());
+    }
+
+    @Test
+    public void testCreateOffer_success() {
+        when(portfolioEntryRepository.findById(1L)).thenReturn(Optional.of(entry));
+        when(otcOfferRepository.save(any(OtcOffer.class))).thenAnswer(i -> i.getArguments()[0]);
+        when(otcOfferMapper.toDto(any(OtcOffer.class))).thenReturn(new OtcOfferDto());
+
+        OtcOfferDto result = otcService.createOffer(dto, buyerId);
+
+        assertNotNull(result);
+        verify(otcOfferRepository, times(1)).save(any(OtcOffer.class));
+        verify(otcOfferMapper).toDto(any(OtcOffer.class));
+    }
+
+    @Test
+    public void testCreateOffer_portfolioEntryNotFound() {
+        when(portfolioEntryRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(PortfolioEntryNotFoundException.class,
+                () -> otcService.createOffer(dto, buyerId));
+    }
+
+    @Test
+    public void testCreateOffer_invalidPublicAmount() {
+        entry.setPublicAmount(10); // manje od onoga što traži dto
+        when(portfolioEntryRepository.findById(1L)).thenReturn(Optional.of(entry));
+
+        assertThrows(InvalidPublicAmountException.class,
+                () -> otcService.createOffer(dto, buyerId));
+    }
+
+    @Test
+    void testAcceptOffer_success() {
+        OtcOffer offer = OtcOffer.builder()
+                .id(1L)
+                .sellerId(123L)
+                .status(OtcOfferStatus.PENDING)
+                .build();
+
+        when(otcOfferRepository.findById(1L)).thenReturn(Optional.of(offer));
+
+        otcService.acceptOffer(1L, 123L);
+
+        assertEquals(OtcOfferStatus.ACCEPTED, offer.getStatus());
+        assertEquals(123L, offer.getLastModifiedById());
+        assertNotNull(offer.getLastModified());
+        verify(otcOfferRepository).save(offer);
+    }
+
+    @Test
+    void testRejectOffer_unauthorized() {
+        OtcOffer offer = OtcOffer.builder()
+                .id(1L)
+                .sellerId(123L)
+                .status(OtcOfferStatus.PENDING)
+                .build();
+
+        when(otcOfferRepository.findById(1L)).thenReturn(Optional.of(offer));
+
+        assertThrows(UnauthorizedActionException.class, () -> otcService.rejectOffer(1L, 999L));
+        verify(otcOfferRepository, never()).save(any());
+    }
+
+    @Test
+    void testUpdateOffer_success() {
+        Long offerId = 1L;
+        Long sellerId = 100L;
+
+        OtcOffer existingOffer = OtcOffer.builder()
+                .id(offerId)
+                .sellerId(sellerId)
+                .status(OtcOfferStatus.PENDING)
+                .lastModified(LocalDateTime.now().minusDays(1))
+                .build();
+
+        CreateOtcOfferDto dto = new CreateOtcOfferDto();
+        dto.setAmount(BigDecimal.TEN);
+        dto.setPricePerStock(new BigDecimal("100"));
+        dto.setPremium(new BigDecimal("5"));
+        dto.setSettlementDate(LocalDate.now().plusDays(7));
+
+        when(otcOfferRepository.findById(offerId)).thenReturn(Optional.of(existingOffer));
+
+        otcService.updateOffer(offerId, sellerId, dto);
+
+        verify(otcOfferRepository).save(argThat(updatedOffer ->
+                updatedOffer.getAmount() == 10 &&
+                        updatedOffer.getPricePerStock().equals(new BigDecimal("100")) &&
+                        updatedOffer.getPremium().equals(new BigDecimal("5")) &&
+                        updatedOffer.getSettlementDate().equals(dto.getSettlementDate()) &&
+                        updatedOffer.getStatus() == OtcOfferStatus.PENDING &&
+                        updatedOffer.getLastModifiedById().equals(sellerId)
+        ));
+    }
+}


### PR DESCRIPTION
…TO-em, mapperom, testovima i validiranim endpointima.

## Opis
Implementirana kompletna OTC funkcionalnost za klijente, uključujući kreiranje, pregled, prihvatanje, odbijanje i kontra-ponude. 
Kreiranje OTC ponude (POST /api/otc)

Pregled svih ponuda koje je korisnik primio (GET /api/otc/received)

Prihvatanje ponude (PUT /api/otc/{id}/accept)

Odbijanje ponude (PUT /api/otc/{id}/reject)

Slanje kontra ponude (PUT /api/otc/{id}/counter)

## Screenshot-ovi (ako je primenjivo)
![image](https://github.com/user-attachments/assets/9bce4015-0323-4919-bd9a-6f4ff6b173ff)

![image](https://github.com/user-attachments/assets/b94c6fc0-1324-4177-af42-24f28d129088)

![image](https://github.com/user-attachments/assets/d354212f-8c58-495a-8bae-8f56d1daac5c)

![image](https://github.com/user-attachments/assets/e244d85f-f640-470d-a79f-1ed4449e630b)

![image](https://github.com/user-attachments/assets/ec70969a-18ca-4841-8684-80a01c4723ec)

![image](https://github.com/user-attachments/assets/070416c2-dc7b-48b1-ad25-41ecc1ad48ab)


## Objašnjenje korisničkog toka (ako je primenjivo)
Klijent kreira OTC ponudu za javno dostupne akcije koje neko drugi poseduje (POST /api/otc).

Prodavac vidi sve primljene ponude u GET /api/otc/received.

Prodavac može da:

prihvati ponudu preko PUT /api/otc/{id}/accept

odbije ponudu preko PUT /api/otc/{id}/reject

pošalje kontra-ponudu putem PUT /api/otc/{id}/counter, gde unosi nove uslove

Svi odgovori su validirani i vraćaju korisnički čitljive poruke ili DTO objekte.

## Dodatne napomene

Mapper koristi StockMapper za ugnježdene entitete u DTO-ima.