### PR TITLE
uradjeno Iskoriscavanje opcije (van OTC) #205

### DIFF
--- a/stock-service/src/main/java/rs/raf/stock_service/StockServiceApplication.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/StockServiceApplication.java
@@ -6,6 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
 
+import java.io.File;
+
 @SpringBootApplication
 @EnableFeignClients
 @EnableAsync

--- a/stock-service/src/main/java/rs/raf/stock_service/controller/PortfolioController.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/controller/PortfolioController.java
@@ -8,10 +8,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-import rs.raf.stock_service.domain.dto.PortfolioEntryDto;
-import rs.raf.stock_service.domain.dto.PublicStockDto;
-import rs.raf.stock_service.domain.dto.SetPublicAmountDto;
-import rs.raf.stock_service.domain.dto.TaxGetResponseDto;
+import rs.raf.stock_service.domain.dto.*;
+import rs.raf.stock_service.exceptions.OptionNotEligibleException;
 import rs.raf.stock_service.service.PortfolioService;
 import rs.raf.stock_service.utils.JwtTokenUtil;
 
@@ -104,5 +102,25 @@ public class PortfolioController {
     public ResponseEntity<TaxGetResponseDto>getTaxes(@RequestHeader("Authorization") String authHeader){
         return ResponseEntity.ok().body(portfolioService.getTaxes(authHeader));
 
+    }
+    @PreAuthorize("hasAnyRole('CLIENT', 'AGENT')")
+    @PostMapping("/use-option")
+    @Operation(summary = "Use option (CALL/PUT) if eligible")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Option used successfully"),
+            @ApiResponse(responseCode = "400", description = "Option not eligible or invalid request"),
+            @ApiResponse(responseCode = "500", description = "Unexpected server error")
+    })
+    public ResponseEntity<?> useOption(@RequestHeader("Authorization") String authHeader,
+                                       @RequestBody UseOptionDto dto) {
+        try {
+            Long userId = jwtTokenUtil.getUserIdFromAuthHeader(authHeader);
+            portfolioService.useOption(userId, dto);
+            return ResponseEntity.ok().build();
+        } catch (OptionNotEligibleException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 }

--- a/stock-service/src/main/java/rs/raf/stock_service/domain/dto/UseOptionDto.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/domain/dto/UseOptionDto.java
@@ -1,0 +1,8 @@
+package rs.raf.stock_service.domain.dto;
+
+import lombok.Data;
+
+@Data
+public class UseOptionDto {
+    private Long portfolioEntryId;
+}

--- a/stock-service/src/main/java/rs/raf/stock_service/exceptions/OptionNotEligibleException.java
+++ b/stock-service/src/main/java/rs/raf/stock_service/exceptions/OptionNotEligibleException.java
@@ -1,0 +1,7 @@
+package rs.raf.stock_service.exceptions;
+
+public class OptionNotEligibleException extends RuntimeException {
+    public OptionNotEligibleException(String message) {
+        super(message);
+    }
+}

--- a/stock-service/src/test/java/unit/PortfolioServiceTest.java
+++ b/stock-service/src/test/java/unit/PortfolioServiceTest.java
@@ -13,6 +13,7 @@ import rs.raf.stock_service.domain.dto.PublicStockDto;
 import rs.raf.stock_service.domain.dto.SetPublicAmountDto;
 import rs.raf.stock_service.domain.entity.*;
 import rs.raf.stock_service.domain.enums.ListingType;
+import rs.raf.stock_service.domain.enums.OptionType;
 import rs.raf.stock_service.exceptions.InvalidListingTypeException;
 import rs.raf.stock_service.exceptions.InvalidPublicAmountException;
 import rs.raf.stock_service.exceptions.OptionNotEligibleException;
@@ -354,25 +355,27 @@ public class PortfolioServiceTest {
     @Test
     void testUseOption_SuccessfulExecution() {
         // Postavljanje mock podataka
+        Stock underlying = new Stock();
+        underlying.setPrice(BigDecimal.valueOf(110)); // veće od strikePrice = 100
+
+        Option option = new Option();
+        option.setOptionType(OptionType.CALL); // <----- KLJUČNO!
+        option.setStrikePrice(BigDecimal.valueOf(100));
+        option.setContractSize(BigDecimal.valueOf(10));
+        option.setSettlementDate(LocalDate.now().plusDays(5));
+        option.setUnderlyingStock(underlying); // <----- KLJUČNO!
+
         PortfolioEntry optionEntry = new PortfolioEntry();
         optionEntry.setUserId(userId);
         optionEntry.setAmount(10);
         optionEntry.setUsed(false);
-        optionEntry.setInTheMoney(true);
+        optionEntry.setInTheMoney(true); // nebitno sad
         optionEntry.setType(ListingType.OPTION);
-
-        Option option = new Option();
-        option.setStrikePrice(BigDecimal.valueOf(100));
-        option.setContractSize(BigDecimal.valueOf(10));
-        option.setSettlementDate(LocalDate.now().plusDays(5));  // Postavljanje settlementDate
-        option.setUnderlyingStock(new Stock()); // Set underlying stock
-
-
-        optionEntry.setListing(option);  // Povezivanje optionEntry sa opcijom (ovo je ključna linija)
+        optionEntry.setListing(option);
 
         when(portfolioEntryRepository.findByUserIdAndId(userId, optionEntry.getId()))
                 .thenReturn(Optional.of(optionEntry));
-        when(portfolioEntryRepository.findByUserIdAndListing(userId, option.getUnderlyingStock()))
+        when(portfolioEntryRepository.findByUserIdAndListing(userId, underlying))
                 .thenReturn(Optional.empty());
 
         UseOptionDto useOptionDto = new UseOptionDto();
@@ -381,28 +384,37 @@ public class PortfolioServiceTest {
         // Pozivanje servisa
         portfolioService.useOption(userId, useOptionDto);
 
-        // Proveri da li su se podaci ispravno ažurirali
+        // Provera
         assertTrue(optionEntry.getUsed(), "Option should be marked as used.");
-        verify(portfolioEntryRepository, times(2)).save(any(PortfolioEntry.class));  // Proverava da li su sačuvana dva entiteta
+        verify(portfolioEntryRepository, times(2)).save(any(PortfolioEntry.class));
     }
 
     @Test
     void testUseOption_ThrowsException_IfOptionNotInTheMoney() {
-        // Postavljanje mock podataka
+        // Postavljanje underlying stocka sa cenom koja nije povoljna (manja za CALL)
+        Stock underlying = new Stock();
+        underlying.setPrice(BigDecimal.valueOf(90)); // manja od strikePrice = 100
+
+        Option option = new Option();
+        option.setOptionType(OptionType.CALL); // <----- važno!
+        option.setStrikePrice(BigDecimal.valueOf(100));
+        option.setContractSize(BigDecimal.valueOf(10));
+        option.setSettlementDate(LocalDate.now().plusDays(5));
+        option.setUnderlyingStock(underlying);
+
         PortfolioEntry optionEntry = new PortfolioEntry();
         optionEntry.setUserId(userId);
-        optionEntry.setListing(new Option());
+        optionEntry.setListing(option);
         optionEntry.setAmount(10);
         optionEntry.setUsed(false);
-        optionEntry.setInTheMoney(false);  // Postavljanje da nije in-the-money
         optionEntry.setType(ListingType.OPTION);
 
         when(portfolioEntryRepository.findByUserIdAndId(userId, optionEntry.getId()))
                 .thenReturn(Optional.of(optionEntry));
+
         UseOptionDto useOptionDto = new UseOptionDto();
         useOptionDto.setPortfolioEntryId(optionEntry.getId());
 
-        // Testiranje izuzetka
         assertThrows(OptionNotEligibleException.class, () ->
                 portfolioService.useOption(userId, useOptionDto));
     }
@@ -459,26 +471,28 @@ public class PortfolioServiceTest {
 
     @Test
     void testUseOption_CreatesNewPortfolioEntry_WhenUnderlyingNotExist() {
-        // Postavljanje mock podataka
+        // Postavljanje underlying stocka sa cenom povoljnijom za CALL
+        Stock underlying = new Stock();
+        underlying.setPrice(BigDecimal.valueOf(110)); // veća od strike -> in the money za CALL
+
+        Option option = new Option();
+        option.setOptionType(OptionType.CALL);
+        option.setStrikePrice(BigDecimal.valueOf(100));
+        option.setContractSize(BigDecimal.valueOf(10));
+        option.setSettlementDate(LocalDate.now().plusDays(5));
+        option.setUnderlyingStock(underlying);
+
         PortfolioEntry optionEntry = new PortfolioEntry();
         optionEntry.setUserId(userId);
         optionEntry.setAmount(10);
         optionEntry.setUsed(false);
-        optionEntry.setInTheMoney(true);
         optionEntry.setType(ListingType.OPTION);
-
-        Option option = new Option();
-        option.setStrikePrice(BigDecimal.valueOf(100));
-        option.setContractSize(BigDecimal.valueOf(10));
-        option.setSettlementDate(LocalDate.now().plusDays(5));
-        option.setUnderlyingStock(new Stock()); // Set underlying stock
-
         optionEntry.setListing(option); // Povezivanje optionEntry sa opcijom
 
         when(portfolioEntryRepository.findByUserIdAndId(userId, optionEntry.getId()))
                 .thenReturn(Optional.of(optionEntry));
-        when(portfolioEntryRepository.findByUserIdAndListing(userId, option.getUnderlyingStock()))
-                .thenReturn(Optional.empty()); // Simulacija da nema postojećeg entry-ja za underlying stock
+        when(portfolioEntryRepository.findByUserIdAndListing(userId, underlying))
+                .thenReturn(Optional.empty());
 
         UseOptionDto useOptionDto = new UseOptionDto();
         useOptionDto.setPortfolioEntryId(optionEntry.getId());
@@ -487,6 +501,111 @@ public class PortfolioServiceTest {
         portfolioService.useOption(userId, useOptionDto);
 
         // Proveri da li je nova stavka sačuvana
-        verify(portfolioEntryRepository, times(2)).save(any(PortfolioEntry.class));  // Proverava da li su sačuvana dva entiteta
+        verify(portfolioEntryRepository, times(2)).save(any(PortfolioEntry.class));
+    }
+    @Test
+    void testUseOption_SuccessfullyExecutes_WhenCallAndInTheMoney() {
+        // priprema podataka
+        Stock underlyingStock = new Stock();
+        underlyingStock.setPrice(BigDecimal.valueOf(120));
+        underlyingStock.setType(ListingType.STOCK);
+
+        Option option = new Option();
+        option.setOptionType(OptionType.CALL);
+        option.setStrikePrice(BigDecimal.valueOf(100));
+        option.setContractSize(BigDecimal.valueOf(2));
+        option.setSettlementDate(LocalDate.now().plusDays(5));
+        option.setUnderlyingStock(underlyingStock);
+
+        PortfolioEntry optionEntry = PortfolioEntry.builder()
+                .id(1L)
+                .userId(userId)
+                .amount(5)
+                .listing(option)
+                .used(false)
+                .inTheMoney(false) // više se ne koristi
+                .type(ListingType.OPTION)
+                .build();
+
+        when(portfolioEntryRepository.findByUserIdAndId(userId, 1L))
+                .thenReturn(Optional.of(optionEntry));
+        when(portfolioEntryRepository.findByUserIdAndListing(userId, underlyingStock))
+                .thenReturn(Optional.empty());
+
+        UseOptionDto dto = new UseOptionDto();
+        dto.setPortfolioEntryId(1L);
+
+        portfolioService.useOption(userId, dto);
+
+        // Provera da li je opcija iskorišćena
+        assertTrue(optionEntry.getUsed());
+        verify(portfolioEntryRepository, times(2)).save(any(PortfolioEntry.class));
+    }
+    @Test
+    void testUseOption_SuccessfullyExecutes_WhenPutAndInTheMoney() {
+        // Priprema podataka
+        Stock underlyingStock = new Stock();
+        underlyingStock.setPrice(BigDecimal.valueOf(80));
+        underlyingStock.setType(ListingType.STOCK);
+
+        Option option = new Option();
+        option.setOptionType(OptionType.PUT);
+        option.setStrikePrice(BigDecimal.valueOf(100));
+        option.setContractSize(BigDecimal.valueOf(2));
+        option.setSettlementDate(LocalDate.now().plusDays(5));
+        option.setUnderlyingStock(underlyingStock);
+
+        PortfolioEntry optionEntry = PortfolioEntry.builder()
+                .id(2L)
+                .userId(userId)
+                .amount(5)
+                .listing(option)
+                .used(false)
+                .inTheMoney(false) // više se ne koristi direktno
+                .type(ListingType.OPTION)
+                .build();
+
+        when(portfolioEntryRepository.findByUserIdAndId(userId, 2L))
+                .thenReturn(Optional.of(optionEntry));
+        when(portfolioEntryRepository.findByUserIdAndListing(userId, underlyingStock))
+                .thenReturn(Optional.empty());
+
+        UseOptionDto dto = new UseOptionDto();
+        dto.setPortfolioEntryId(2L);
+
+        portfolioService.useOption(userId, dto);
+
+        assertTrue(optionEntry.getUsed());
+        verify(portfolioEntryRepository, times(2)).save(any(PortfolioEntry.class));
+    }
+    @Test
+    void testUseOption_ThrowsException_WhenCallOptionNotInTheMoney() {
+        Stock underlyingStock = new Stock();
+        underlyingStock.setPrice(BigDecimal.valueOf(90));
+
+        Option option = new Option();
+        option.setOptionType(OptionType.CALL);
+        option.setStrikePrice(BigDecimal.valueOf(100));
+        option.setContractSize(BigDecimal.ONE);
+        option.setSettlementDate(LocalDate.now().plusDays(5));
+        option.setUnderlyingStock(underlyingStock);
+
+        PortfolioEntry optionEntry = PortfolioEntry.builder()
+                .id(3L)
+                .userId(userId)
+                .amount(1)
+                .listing(option)
+                .used(false)
+                .inTheMoney(true) // ali se više ne koristi
+                .type(ListingType.OPTION)
+                .build();
+
+        when(portfolioEntryRepository.findByUserIdAndId(userId, 3L))
+                .thenReturn(Optional.of(optionEntry));
+
+        UseOptionDto dto = new UseOptionDto();
+        dto.setPortfolioEntryId(3L);
+
+        assertThrows(OptionNotEligibleException.class, () -> portfolioService.useOption(userId, dto));
     }
 }


### PR DESCRIPTION
## Opis
Implementirana je funkcionalnost za iskorišćavanje opcija (van OTC) u okviru PortfolioService-a. 

Kreiran je novi endpoint:
POST /api/portfolio/use-option

Endpoint omogućava klijentima sa opcijama da ih iskoriste ukoliko su:

U "in the money" poziciji (zavisi od tipa opcije: CALL ili PUT)
Opcija nije već iskorišćena (used = false)
Nije prošao datum dospeća (settlementDate)

Ako ovi uslovi nisu ispunjeni, baca se odgovarajući exception (OptionNotEligibleForExecutionException).

Kad se opcija uspešno iskoristi:
Polje used se postavlja na true.
Ažurira se stanje portfolija korisnika.

## Screenshot-ovi (ako je primenjivo)
![image](https://github.com/user-attachments/assets/5481cbe5-a275-4e72-9ea7-44ea5762a8e9)
![image](https://github.com/user-attachments/assets/f804ec86-0eed-4320-a830-5671bff735d0)
![image](https://github.com/user-attachments/assets/c1ef8c4a-b672-4994-a26d-c95327adec07)
Nakon testiranja used polje (postavljeno na true): 
![image](https://github.com/user-attachments/assets/cae6aca0-726b-4dfa-a6ff-0e3809cf02df)
